### PR TITLE
feat(ActiveAdmin): Add ActiveAdminAddon gem to admin recipe

### DIFF
--- a/lib/potassium/templates/application/recipes/admin.rb
+++ b/lib/potassium/templates/application/recipes/admin.rb
@@ -1,6 +1,7 @@
 if get(:admin_mode)
   if equals?(:authentication, :devise)
     gather_gem 'activeadmin', github: 'activeadmin'
+    gather_gem 'activeadmin_addons'
 
     after(:gem_install, :wrap_in_action => :admin_install) do
       generate "active_admin:install"

--- a/lib/potassium/templates/application/recipes/asks/admin.rb
+++ b/lib/potassium/templates/application/recipes/asks/admin.rb
@@ -1,11 +1,5 @@
 if equals?(:authentication, :devise)
   admin_mode = Ask.confirm "Do you want to use ActiveAdmin?"
-  if admin_mode
-    admin_mode = Ask.confirm "Do you really want to use ActiveAdmin?"
-    if admin_mode
-      admin_mode = Ask.confirm "Do you really, really want to use ActiveAdmin?"
-    end
-  end
 
   set(:admin_mode, admin_mode)
 end


### PR DESCRIPTION
I think it's safe to say we should use activeadmin_addons if we use activeadmin at all