### PR TITLE
fix(rbenv-vars): Fix database name

### DIFF
--- a/lib/potassium/templates/application/assets/.rbenv-vars.example
+++ b/lib/potassium/templates/application/assets/.rbenv-vars.example
@@ -1,4 +1,4 @@
-DB_NAME=<%= @app_name.downcase %>
+DB_NAME=<%= get(:underscorized_app_name) %>
 DB_USER=root
 DB_PASSWORD=
 DEFAULT_EMAIL_ADDRESS=


### PR DESCRIPTION
The name of the created database was not the same
saved on the `.rbenv-vars`

[Closes #9]