### PR TITLE
feat(rbenv): gets ruby version from service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+Features:
+
+  - Gets ruby version from http://ruby.platan.us/latest
+
 ## 1.4
 
 Features:

--- a/lib/potassium/templates/application/recipes/rbenv.rb
+++ b/lib/potassium/templates/application/recipes/rbenv.rb
@@ -1,4 +1,23 @@
+require 'net/http'
+require 'semantic'
+require 'pry'
+
+def latest
+  printf 'Getting platanus latest ruby version...'
+  Net::HTTP.get(URI.parse('http://ruby.platan.us/latest'))
+rescue
+  puts " not found, using #{RUBY_VERSION}"
+  RUBY_VERSION
+end
+
+def version_alias
+  version = latest
+
+  puts "using #{version}"
+  Semantic::Version.new(version).instance_eval { "#{major}.#{minor}" }
+end
+
 create_file '.rbenv-vars'
 template 'assets/.rbenv-vars.example', '.rbenv-vars.example'
 run "cp .rbenv-vars.example .rbenv-vars"
-create_file '.ruby-version', '2.2'
+create_file '.ruby-version', version_alias


### PR DESCRIPTION
The idea is to have a endpoint to get the latests ruby version that we
are using at platanus. The endpoint is http://ruby.platan.us/latest

Potassium get the version the the service and generates the
corresponding `.ruby-version`

If the service is down, if fallback to whatever ruby version potassium
it's being run. This is done via the RBENV_VERSION environmental
variable.