### PR TITLE
fix(heroku): Move logging gem to the correct groups

### DIFF
--- a/lib/potassium/templates/application/recipes/heroku.rb
+++ b/lib/potassium/templates/application/recipes/heroku.rb
@@ -1,5 +1,5 @@
 if get(:heroku)
-  gather_gems(:development, :test) do
+  gather_gems(:production, :staging) do
     gather_gem('rails_stdout_logging')
   end
 


### PR DESCRIPTION
closes #43 