### PR TITLE
Remote rubocop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.a
 mkmf.log
 .DS_Store
+.rubocop-http*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 inherit_from:
-  - ~/.rubocop.yml
+  - https://raw.githubusercontent.com/platanus/hound/platanus/config/style_guides/platanus/ruby.yml
   - .ruby_style.yml

--- a/lib/potassium/version.rb
+++ b/lib/potassium/version.rb
@@ -1,5 +1,5 @@
 module Potassium
   VERSION = "1.3.5"
   RAILS_VERSION = "~> 4.2.0"
-  RUBOCOP_VERSION = "~> 0.37.2"
+  RUBOCOP_VERSION = "~> 0.38.0"
 end


### PR DESCRIPTION
I was testing this over the refactor..

I think there is something wrong about the rubocop test. 

Rubocop should use the configuration files in the dummy project not the one on the root of potassium
those could easily diverge and be different. https://github.com/platanus/potassium/blob/remote_rubocop/spec/support/potassium_test_helpers.rb#L91

This also means that we need to complete the #31 issue
