### PR TITLE
change the way the recipes are defined and called

### DIFF
--- a/lib/potassium/generators/recipe.rb
+++ b/lib/potassium/generators/recipe.rb
@@ -3,6 +3,10 @@ require "rails/generators/rails/app/app_generator"
 require "inquirer"
 require "potassium/recipe"
 
+class Rails::AppBuilder
+  include Rails::ActionMethods
+end
+
 module Potassium
   class RecipeGenerator < Rails::Generators::NamedBase
     class << self

--- a/lib/potassium/helpers/template-helpers.rb
+++ b/lib/potassium/helpers/template-helpers.rb
@@ -1,11 +1,22 @@
 module TemplateHelpers
-  def load_recipe(recipe)
-    get_recipe_class(recipe).new(self)
+  def load_recipe(recipe_name)
+    @recipes ||= {}
+    @recipes[recipe_name] ||= get_recipe_class(recipe_name.to_sym).new(self)
   end
 
-  def get_recipe_class(recipe)
-    require_relative "../recipes/#{recipe}"
-    Recipes.const_get(recipe.camelize)
+  def create(recipe_name)
+    recipe = load_recipe(recipe_name)
+    recipe.create
+  end
+
+  def ask(recipe_name)
+    recipe = load_recipe(recipe_name)
+    recipe.ask
+  end
+
+  def install(recipe_name)
+    recipe = load_recipe(recipe_name)
+    recipe.install
   end
 
   def eval_file(source)
@@ -50,5 +61,12 @@ module TemplateHelpers
   def dir_exist?(dir_path)
     full_path = File.join(destination_root, dir_path)
     Dir.exist?(full_path)
+  end
+
+  private
+
+  def get_recipe_class(recipe_name)
+    require_relative "../recipes/#{recipe_name}"
+    Recipes.const_get(recipe_name.to_s.camelize)
   end
 end

--- a/lib/potassium/recipe.rb
+++ b/lib/potassium/recipe.rb
@@ -1,11 +1,2 @@
 module Recipes
-  class Base
-    def initialize(template)
-      self.t = template
-    end
-
-    private
-
-    attr_accessor :t
-  end
 end

--- a/lib/potassium/recipes/admin.rb
+++ b/lib/potassium/recipes/admin.rb
@@ -1,39 +1,39 @@
-class Recipes::Admin < Recipes::Base
+class Recipes::Admin < Rails::AppBuilder
   def ask
-    if t.selected?(:authentication)
-      admin_mode = t.answer(:admin) { Ask.confirm("Do you want to use ActiveAdmin?") }
-      t.set(:admin_mode, admin_mode)
+    if selected?(:authentication)
+      admin_mode = answer(:admin) { Ask.confirm("Do you want to use ActiveAdmin?") }
+      set(:admin_mode, admin_mode)
     end
   end
 
   def create
-    if t.selected?(:admin_mode)
-      if t.selected?(:authentication)
+    if selected?(:admin_mode)
+      if selected?(:authentication)
         add_active_admin
       else
-        t.info "ActiveAdmin can't be installed because Devise isn't enabled."
+        info "ActiveAdmin can't be installed because Devise isn't enabled."
       end
     end
   end
 
   def install
-    if t.gem_exists?(/activeadmin/)
-      t.info "ActiveAdmin is already installed"
-    elsif t.gem_exists?(/devise/)
+    if gem_exists?(/activeadmin/)
+      info "ActiveAdmin is already installed"
+    elsif gem_exists?(/devise/)
       add_active_admin
     else
-      t.info "ActiveAdmin can't be installed because Devise isn't installed."
+      info "ActiveAdmin can't be installed because Devise isn't installed."
     end
   end
 
   private
 
   def add_active_admin
-    t.gather_gem 'activeadmin', github: 'activeadmin'
-    t.gather_gem 'activeadmin_addons'
-    t.gather_gem 'active_skin'
+    gather_gem 'activeadmin', github: 'activeadmin'
+    gather_gem 'activeadmin_addons'
+    gather_gem 'active_skin'
 
-    t.after(:gem_install, wrap_in_action: :admin_install) do
+    after(:gem_install, wrap_in_action: :admin_install) do
       generate "active_admin:install"
       line = "ActiveAdmin.setup do |config|"
       initializer = "config/initializers/active_admin.rb"

--- a/lib/potassium/recipes/angular_admin.rb
+++ b/lib/potassium/recipes/angular_admin.rb
@@ -1,53 +1,53 @@
-class Recipes::AngularAdmin < Recipes::Base
+class Recipes::AngularAdmin < Rails::AppBuilder
   def ask
-    if t.selected?(:admin_mode)
-      angular_admin = t.answer(:"angular-admin") do
+    if selected?(:admin_mode)
+      angular_admin = answer(:"angular-admin") do
         Ask.confirm "Do you want Angular support for ActiveAdmin?"
       end
-      t.set(:angular_admin, angular_admin)
+      set(:angular_admin, angular_admin)
     end
   end
 
   def create
     recipe = self
-    if t.selected?(:angular_admin)
-      t.after(:admin_install) do
+    if selected?(:angular_admin)
+      after(:admin_install) do
         recipe.add_angular_admin
       end
     end
   end
 
   def install
-    if t.dir_exist?("app/assets/javascripts/admin")
-      t.info "ActiveAdmin is already installed"
-    elsif t.gem_exists?(/activeadmin/)
+    if dir_exist?("app/assets/javascripts/admin")
+      info "ActiveAdmin is already installed"
+    elsif gem_exists?(/activeadmin/)
       add_angular_admin
     else
-      t.info "ActiveAdmin can't be installed because Active Admin isn't installed."
+      info "ActiveAdmin can't be installed because Active Admin isn't installed."
     end
   end
 
   def add_angular_admin
-    t.copy_file '../assets/active_admin/init_activeadmin_angular.rb',
+    copy_file '../assets/active_admin/init_activeadmin_angular.rb',
       'config/initializers/init_activeadmin_angular.rb'
 
-    t.create_file 'app/assets/javascripts/admin_app.js', "angular.module('ActiveAdmin', []);"
+    create_file 'app/assets/javascripts/admin_app.js', "angular.module('ActiveAdmin', []);"
 
-    t.copy_file '../assets/active_admin/active_admin.js.coffee',
+    copy_file '../assets/active_admin/active_admin.js.coffee',
       'app/assets/javascripts/active_admin.js.coffee',
       force: true
 
-    t.empty_directory 'app/assets/javascripts/admin'
-    t.empty_directory 'app/assets/javascripts/admin/controllers'
-    t.empty_directory 'app/assets/javascripts/admin/services'
-    t.empty_directory 'app/assets/javascripts/admin/directives'
+    empty_directory 'app/assets/javascripts/admin'
+    empty_directory 'app/assets/javascripts/admin/controllers'
+    empty_directory 'app/assets/javascripts/admin/services'
+    empty_directory 'app/assets/javascripts/admin/directives'
 
-    t.create_file 'app/assets/javascripts/admin/controllers/.keep'
-    t.create_file 'app/assets/javascripts/admin/services/.keep'
-    t.create_file 'app/assets/javascripts/admin/directives/.keep'
+    create_file 'app/assets/javascripts/admin/controllers/.keep'
+    create_file 'app/assets/javascripts/admin/services/.keep'
+    create_file 'app/assets/javascripts/admin/directives/.keep'
 
-    t.inside('.') do
-      t.run('bower install angular --save')
+    inside('.') do
+      run('bower install angular --save')
     end
   end
 end

--- a/lib/potassium/recipes/api.rb
+++ b/lib/potassium/recipes/api.rb
@@ -1,16 +1,16 @@
-class Recipes::Api < Recipes::Base
+class Recipes::Api < Rails::AppBuilder
   def ask
-    api_support = t.answer(:api) { Ask.confirm("Do you want to enable API support?") }
-    t.set(:api_support, api_support)
+    api_support = answer(:api) { Ask.confirm("Do you want to enable API support?") }
+    set(:api_support, api_support)
   end
 
   def create
-    add_api if t.get(:api_support)
+    add_api if get(:api_support)
   end
 
   def install
-    if t.gem_exists?(/versionist/)
-      t.info "API related stuff are already installed"
+    if gem_exists?(/versionist/)
+      info "API related stuff are already installed"
     else
       add_api
     end
@@ -19,12 +19,12 @@ class Recipes::Api < Recipes::Base
   private
 
   def add_api
-    t.gather_gem 'versionist'
-    t.gather_gem 'responders'
-    t.gather_gem 'active_model_serializers', '~> 0.9.3'
-    t.gather_gem 'simple_token_authentication', '~> 1.0'
+    gather_gem 'versionist'
+    gather_gem 'responders'
+    gather_gem 'active_model_serializers', '~> 0.9.3'
+    gather_gem 'simple_token_authentication', '~> 1.0'
 
-    t.after(:gem_install) do
+    after(:gem_install) do
       line = "Rails.application.routes.draw do\n"
       insert_into_file "config/routes.rb", after: line do
         <<-HERE.gsub(/^ {8}/, '')

--- a/lib/potassium/recipes/aws_sdk.rb
+++ b/lib/potassium/recipes/aws_sdk.rb
@@ -1,5 +1,5 @@
-class Recipes::AwsSdk < Recipes::Base
+class Recipes::AwsSdk < Rails::AppBuilder
   def create
-    t.gather_gem('aws-sdk', '< 2')
+    gather_gem('aws-sdk', '< 2')
   end
 end

--- a/lib/potassium/recipes/bower.rb
+++ b/lib/potassium/recipes/bower.rb
@@ -1,13 +1,13 @@
-class Recipes::Bower < Recipes::Base
+class Recipes::Bower < Rails::AppBuilder
   def create
-    t.copy_file '../assets/.bowerrc', '.bowerrc'
-    t.template '../assets/bower.json', 'bower.json'
-    t.application "config.assets.paths << Rails.root.join('vendor', 'assets', 'bower_components')"
+    copy_file '../assets/.bowerrc', '.bowerrc'
+    template '../assets/bower.json', 'bower.json'
+    application "config.assets.paths << Rails.root.join('vendor', 'assets', 'bower_components')"
 
-    if t.get(:heroku)
+    if get(:heroku)
       bower_buildpack_url = 'https://github.com/platanus/heroku-buildpack-bower.git'
       insert_point = 'https://github.com/platanus/heroku-buildpack-ruby-version.git'
-      t.inject_into_file '.buildpacks', "#{bower_buildpack_url}\n", before: insert_point
+      inject_into_file '.buildpacks', "#{bower_buildpack_url}\n", before: insert_point
     end
   end
 end

--- a/lib/potassium/recipes/ci.rb
+++ b/lib/potassium/recipes/ci.rb
@@ -1,17 +1,17 @@
-class Recipes::Ci < Recipes::Base
+class Recipes::Ci < Rails::AppBuilder
   def create
-    if t.get(:heroku)
-      t.copy_file '../assets/Dockerfile.ci', 'Dockerfile.ci'
-      t.copy_file '../assets/circle.yml', 'circle.yml'
+    if get(:heroku)
+      copy_file '../assets/Dockerfile.ci', 'Dockerfile.ci'
+      copy_file '../assets/circle.yml', 'circle.yml'
 
-      t.template '../assets/bin/cibuild.erb', 'bin/cibuild'
-      t.run "chmod a+x bin/cibuild"
+      template '../assets/bin/cibuild.erb', 'bin/cibuild'
+      run "chmod a+x bin/cibuild"
 
-      t.copy_file '../assets/docker-compose.ci.yml', 'docker-compose.ci.yml'
+      copy_file '../assets/docker-compose.ci.yml', 'docker-compose.ci.yml'
 
       compose = DockerHelpers.new('docker-compose.ci.yml')
 
-      if t.selected?(:database, :mysql)
+      if selected?(:database, :mysql)
         service = <<-YAML
           image: "mysql:5.6.23"
           environment:
@@ -22,7 +22,7 @@ class Recipes::Ci < Recipes::Base
         compose.add_env('test', 'MYSQL_HOST', 'mysql')
         compose.add_env('test', 'MYSQL_PORT', '3306')
 
-      elsif t.selected?(:database, :postgresql)
+      elsif selected?(:database, :postgresql)
         service = <<-YAML
           image: "postgres:9.4.5"
           environment:

--- a/lib/potassium/recipes/cleanup.rb
+++ b/lib/potassium/recipes/cleanup.rb
@@ -1,10 +1,10 @@
-class Recipes::Cleanup < Recipes::Base
+class Recipes::Cleanup < Rails::AppBuilder
   def create
-    t.erase_comments "config/application.rb"
-    t.erase_comments "config/environments/production.rb"
-    t.erase_comments "config/environments/staging.rb"
-    t.erase_comments "config/environments/test.rb"
-    t.erase_comments "config/environments/development.rb"
-    t.cut_comments "config/initializers/backtrace_silencers.rb", limit: 100
+    erase_comments "config/application.rb"
+    erase_comments "config/environments/production.rb"
+    erase_comments "config/environments/staging.rb"
+    erase_comments "config/environments/test.rb"
+    erase_comments "config/environments/development.rb"
+    cut_comments "config/initializers/backtrace_silencers.rb", limit: 100
   end
 end

--- a/lib/potassium/recipes/database.rb
+++ b/lib/potassium/recipes/database.rb
@@ -1,4 +1,4 @@
-class Recipes::Database < Recipes::Base
+class Recipes::Database < Rails::AppBuilder
   def ask
     databases = {
       mysql: "MySQL",
@@ -6,11 +6,11 @@ class Recipes::Database < Recipes::Base
       none: "None, thanks"
     }
 
-    database = t.answer(:db) do
+    database = answer(:db) do
       databases.keys[Ask.list("Which database are you using?", databases.values)]
     end
 
-    t.set :database, database.to_sym
+    set :database, database.to_sym
   end
 
   def create
@@ -19,7 +19,7 @@ class Recipes::Database < Recipes::Base
       postgresql: { name: 'postgresql', gem_name: 'pg', relational: true }
     }
 
-    if db = databases[t.get(:database)]
+    if db = databases[get(:database)]
       if db[:relational]
         activate_for_active_record(db)
       end
@@ -29,14 +29,14 @@ class Recipes::Database < Recipes::Base
   private
 
   def activate_for_active_record(db)
-    t.remove_file 'config/database.yml'
-    t.template "../assets/config/database_#{db[:name]}.yml.erb", 'config/database.yml'
+    remove_file 'config/database.yml'
+    template "../assets/config/database_#{db[:name]}.yml.erb", 'config/database.yml'
 
-    t.discard_gem 'sqlite3'
+    discard_gem 'sqlite3'
     if db[:version]
-      t.gather_gem db[:gem_name], db[:version]
+      gather_gem db[:gem_name], db[:version]
     else
-      t.gather_gem db[:gem_name]
+      gather_gem db[:gem_name]
     end
   end
 end

--- a/lib/potassium/recipes/delayed_job.rb
+++ b/lib/potassium/recipes/delayed_job.rb
@@ -1,18 +1,18 @@
-class Recipes::DelayedJob < Recipes::Base
+class Recipes::DelayedJob < Rails::AppBuilder
   def ask
-    use_delayed_job = t.answer(:"delayed-job") { Ask.confirm("Do you want to use delayed jobs?") }
-    t.set(:delayed_job, use_delayed_job)
+    use_delayed_job = answer(:"delayed-job") { Ask.confirm("Do you want to use delayed jobs?") }
+    set(:delayed_job, use_delayed_job)
   end
 
   def create
-    add_delayed_job if t.selected?(:delayed_job)
+    add_delayed_job if selected?(:delayed_job)
   end
 
   def install
-    if t.gem_exists?(/delayed_job_active_record/)
-      t.info "Delayed Job is already installed"
+    if gem_exists?(/delayed_job_active_record/)
+      info "Delayed Job is already installed"
     else
-      t.set(:heroku, t.gem_exists?(/rails_stdout_logging/))
+      set(:heroku, gem_exists?(/rails_stdout_logging/))
       add_delayed_job
     end
   end
@@ -20,12 +20,12 @@ class Recipes::DelayedJob < Recipes::Base
   private
 
   def add_delayed_job
-    t.gather_gem "delayed_job_active_record"
+    gather_gem "delayed_job_active_record"
 
     delayed_job_config = "config.active_job.queue_adapter = :delayed_job"
-    t.application(delayed_job_config)
+    application(delayed_job_config)
 
-    t.after(:gem_install) do
+    after(:gem_install) do
       generate "delayed_job:active_record"
       run "bundle binstubs delayed_job"
 

--- a/lib/potassium/recipes/devise.rb
+++ b/lib/potassium/recipes/devise.rb
@@ -1,11 +1,11 @@
-class Recipes::Devise < Recipes::Base
+class Recipes::Devise < Rails::AppBuilder
   def ask
-    use_devise = t.answer(:devise) do
+    use_devise = answer(:devise) do
       Ask.confirm "Do you want to use Devise for authentication? (required for ActiveAdmin)"
     end
 
     if use_devise
-      t.set(:authentication, use_devise)
+      set(:authentication, use_devise)
       ask_for_devise_model
     end
   end
@@ -15,8 +15,8 @@ class Recipes::Devise < Recipes::Base
   end
 
   def install
-    if t.gem_exists?(/devise/)
-      t.info "Devise is already installed"
+    if gem_exists?(/devise/)
+      info "Devise is already installed"
     else
       ask_for_devise_model
       add_devise
@@ -26,18 +26,18 @@ class Recipes::Devise < Recipes::Base
   private
 
   def ask_for_devise_model
-    create_user_model = t.answer(:"devise-user-model") do
+    create_user_model = answer(:"devise-user-model") do
       Ask.confirm "Do you want to create a user model for Devise?"
     end
 
-    t.set(:authentication_model, :user) if create_user_model
+    set(:authentication_model, :user) if create_user_model
   end
 
   def add_devise
-    t.gather_gem 'devise'
-    t.gather_gem 'devise-i18n'
+    gather_gem 'devise'
+    gather_gem 'devise-i18n'
 
-    t.after(:gem_install) do
+    after(:gem_install) do
       generate "devise:install"
 
       if auth_model = get(:authentication_model)

--- a/lib/potassium/recipes/editorconfig.rb
+++ b/lib/potassium/recipes/editorconfig.rb
@@ -1,5 +1,5 @@
-class Recipes::Editorconfig < Recipes::Base
+class Recipes::Editorconfig < Rails::AppBuilder
   def create
-    t.copy_file '../assets/.editorconfig', '.editorconfig'
+    copy_file '../assets/.editorconfig', '.editorconfig'
   end
 end

--- a/lib/potassium/recipes/env.rb
+++ b/lib/potassium/recipes/env.rb
@@ -1,10 +1,10 @@
-class Recipes::Env < Recipes::Base
+class Recipes::Env < Rails::AppBuilder
   def create
-    t.gather_gems(:development, :test) do
+    gather_gems(:development, :test) do
       gather_gem('dotenv-rails')
     end
 
-    t.template '../assets/.env.example.erb', '.env.example'
-    t.run "cp .env.example .env"
+    template '../assets/.env.example.erb', '.env.example'
+    run "cp .env.example .env"
   end
 end

--- a/lib/potassium/recipes/git.rb
+++ b/lib/potassium/recipes/git.rb
@@ -1,6 +1,6 @@
-class Recipes::Git < Recipes::Base
+class Recipes::Git < Rails::AppBuilder
   def create
-    t.after(:database_creation) do
+    after(:database_creation) do
       append_to_file '.gitignore', ".env\n"
       append_to_file '.gitignore', ".powder\n"
       append_to_file '.gitignore', "vendor/assets/bower_components\n"

--- a/lib/potassium/recipes/heroku.rb
+++ b/lib/potassium/recipes/heroku.rb
@@ -1,16 +1,16 @@
-class Recipes::Heroku < Recipes::Base
+class Recipes::Heroku < Rails::AppBuilder
   def ask
-    heroku = t.answer(:heroku) { Ask.confirm("Are you going to deploy to heroku?") }
-    t.set(:heroku, heroku) if heroku
+    heroku = answer(:heroku) { Ask.confirm("Are you going to deploy to heroku?") }
+    set(:heroku, heroku) if heroku
   end
 
   def create
-    add_heroku if t.get(:heroku)
+    add_heroku if get(:heroku)
   end
 
   def install
-    if t.gem_exists?(/rails_stdout_logging/)
-      t.info "Heroku is already installed"
+    if gem_exists?(/rails_stdout_logging/)
+      info "Heroku is already installed"
     else
       add_heroku
     end
@@ -19,11 +19,11 @@ class Recipes::Heroku < Recipes::Base
   private
 
   def add_heroku
-    t.gather_gems(:production, :staging) do
+    gather_gems(:production, :staging) do
       gather_gem('rails_stdout_logging')
     end
 
-    t.copy_file '../assets/Procfile', 'Procfile'
-    t.copy_file '../assets/.buildpacks', '.buildpacks'
+    copy_file '../assets/Procfile', 'Procfile'
+    copy_file '../assets/.buildpacks', '.buildpacks'
   end
 end

--- a/lib/potassium/recipes/i18n.rb
+++ b/lib/potassium/recipes/i18n.rb
@@ -1,26 +1,26 @@
-class Recipes::I18n < Recipes::Base
+class Recipes::I18n < Rails::AppBuilder
   def ask
     languages = {
       es: "Spanish",
       en: "English"
     }
 
-    lang = t.answer(:lang) do
+    lang = answer(:lang) do
       languages.keys[Ask.list("What is the main language of your app?", languages.values)]
     end
 
-    t.set(:lang, lang)
+    set(:lang, lang)
   end
 
   def create
-    t.gather_gem('rails-i18n')
+    gather_gem('rails-i18n')
 
-    if t.equals?(:lang, :es)
-      t.template('../assets/es.yml', 'config/locales/es.yml')
+    if equals?(:lang, :es)
+      template('../assets/es.yml', 'config/locales/es.yml')
     end
 
-    t.gsub_file 'config/application.rb', /# config\.i18n\.default_locale =[^\n]+\n/ do
-      "config.i18n.default_locale = :#{t.get(:lang)}\n"
+    gsub_file 'config/application.rb', /# config\.i18n\.default_locale =[^\n]+\n/ do
+      "config.i18n.default_locale = :#{get(:lang)}\n"
     end
   end
 end

--- a/lib/potassium/recipes/paperclip.rb
+++ b/lib/potassium/recipes/paperclip.rb
@@ -1,23 +1,23 @@
-class Recipes::Paperclip < Recipes::Base
+class Recipes::Paperclip < Rails::AppBuilder
   def ask
-    paperclip = t.answer(:paperclip) { Ask.confirm("Do you want to use Paperclip for uploads?") }
-    t.set(:paperclip, paperclip)
+    paperclip = answer(:paperclip) { Ask.confirm("Do you want to use Paperclip for uploads?") }
+    set(:paperclip, paperclip)
   end
 
   def create
-    add_paperclip if t.selected?(:paperclip)
+    add_paperclip if selected?(:paperclip)
   end
 
   def install
-    if t.gem_exists?(/paperclip/)
-      t.info "Paperclip is already installed"
+    if gem_exists?(/paperclip/)
+      info "Paperclip is already installed"
     else
       add_paperclip
     end
   end
 
   def add_paperclip
-    t.gather_gem 'paperclip', '~> 4.3'
+    gather_gem 'paperclip', '~> 4.3'
     paperclip_config =
       <<-RUBY.gsub(/^ {7}/, '')
          config.paperclip_defaults = {
@@ -27,8 +27,8 @@ class Recipes::Paperclip < Recipes::Base
            }
          }
          RUBY
-    t.application paperclip_config.strip, env: 'production'
-    t.append_to_file '.env.example', 'AWS_BUCKET='
-    t.append_to_file '.env', 'AWS_BUCKET='
+    application paperclip_config.strip, env: 'production'
+    append_to_file '.env.example', 'AWS_BUCKET='
+    append_to_file '.env', 'AWS_BUCKET='
   end
 end

--- a/lib/potassium/recipes/production.rb
+++ b/lib/potassium/recipes/production.rb
@@ -1,6 +1,6 @@
-class Recipes::Production < Recipes::Base
+class Recipes::Production < Rails::AppBuilder
   def create
-    t.gsub_file "config/environments/production.rb", /(\# config.action_mailer.+)/i do |match|
+    gsub_file "config/environments/production.rb", /(\# config.action_mailer.+)/i do |match|
       "#{match}\n  config.action_mailer.default_options = { from: ENV['DEFAULT_EMAIL_ADDRESS'] }\n"
     end
   end

--- a/lib/potassium/recipes/pry.rb
+++ b/lib/potassium/recipes/pry.rb
@@ -1,10 +1,10 @@
-class Recipes::Pry < Recipes::Base
+class Recipes::Pry < Rails::AppBuilder
   def create
-    t.gather_gems(:development, :test) do
+    gather_gems(:development, :test) do
       gather_gem('pry-rails')
       gather_gem('pry-byebug')
     end
 
-    t.template '../assets/.pryrc', '.pryrc'
+    template '../assets/.pryrc', '.pryrc'
   end
 end

--- a/lib/potassium/recipes/puma.rb
+++ b/lib/potassium/recipes/puma.rb
@@ -1,12 +1,12 @@
-class Recipes::Puma < Recipes::Base
+class Recipes::Puma < Rails::AppBuilder
   def create
-    t.gather_gem 'puma'
+    gather_gem 'puma'
 
-    t.gather_gems(:production, :staging) do
+    gather_gems(:production, :staging) do
       gather_gem 'rack-timeout'
     end
 
-    t.copy_file '../assets/config/puma.rb', 'config/puma.rb'
+    copy_file '../assets/config/puma.rb', 'config/puma.rb'
 
     # Configure rack-timout
     rack_timeout_config =
@@ -14,6 +14,6 @@ class Recipes::Puma < Recipes::Base
          Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
          RUBY
 
-    t.append_file "config/environments/production.rb", rack_timeout_config
+    append_file "config/environments/production.rb", rack_timeout_config
   end
 end

--- a/lib/potassium/recipes/pundit.rb
+++ b/lib/potassium/recipes/pundit.rb
@@ -1,18 +1,18 @@
-class Recipes::Pundit < Recipes::Base
+class Recipes::Pundit < Rails::AppBuilder
   def ask
-    if t.get(:authentication).present?
-      use_pundit = t.answer(:pundit) { Ask.confirm("Do you want to use Pundit for authorization?") }
-      t.set(:authorization, use_pundit)
+    if get(:authentication).present?
+      use_pundit = answer(:pundit) { Ask.confirm("Do you want to use Pundit for authorization?") }
+      set(:authorization, use_pundit)
     end
   end
 
   def create
-    if t.selected?(:authorization)
+    if selected?(:authorization)
       run_pundit_installer
       recipe = self
 
-      if t.selected?(:admin_mode)
-        t.after(:admin_install) do
+      if selected?(:admin_mode)
+        after(:admin_install) do
           recipe.install_admin_pundit
         end
       end
@@ -20,18 +20,18 @@ class Recipes::Pundit < Recipes::Base
   end
 
   def install
-    if t.gem_exists?(/pundit/)
-      t.info "Pundit is already installed"
+    if gem_exists?(/pundit/)
+      info "Pundit is already installed"
     else
       run_pundit_installer
-      install_admin_pundit if t.gem_exists?(/activeadmin/)
+      install_admin_pundit if gem_exists?(/activeadmin/)
     end
   end
 
   def run_pundit_installer
-    t.gather_gem 'pundit'
+    gather_gem 'pundit'
 
-    t.after(:gem_install) do
+    after(:gem_install) do
       application_controller = "app/controllers/application_controller.rb"
       gsub_file application_controller, "protect_from_forgery" do
         "include Pundit\n  protect_from_forgery"
@@ -42,15 +42,15 @@ class Recipes::Pundit < Recipes::Base
 
   def install_admin_pundit
     initializer = "config/initializers/active_admin.rb"
-    t.gsub_file initializer, /# config\.authorization_adapter =[^\n]+\n/ do
+    gsub_file initializer, /# config\.authorization_adapter =[^\n]+\n/ do
       "config.authorization_adapter = ActiveAdmin::PunditAdapter\n"
     end
 
-    t.template "../assets/active_admin/pundit_page_policy.rb",
+    template "../assets/active_admin/pundit_page_policy.rb",
       "app/policies/active_admin/page_policy.rb"
-    t.template "../assets/active_admin/comment_policy.rb",
+    template "../assets/active_admin/comment_policy.rb",
       "app/policies/active_admin/comment_policy.rb"
-    t.template "../assets/active_admin/admin_user_policy.rb",
+    template "../assets/active_admin/admin_user_policy.rb",
       "app/policies/admin_user_policy.rb"
   end
 end

--- a/lib/potassium/recipes/rack_cors.rb
+++ b/lib/potassium/recipes/rack_cors.rb
@@ -1,7 +1,7 @@
-class Recipes::RackCors < Recipes::Base
+class Recipes::RackCors < Rails::AppBuilder
   def create
-    t.gather_gem('rack-cors', '~> 0.4.0')
-    t.after(:gem_install) do
+    gather_gem('rack-cors', '~> 0.4.0')
+    after(:gem_install) do
       rack_cors_config =
         <<-RUBY.gsub(/^ {7}/, '')
            config.middleware.insert_before 0, "Rack::Cors" do

--- a/lib/potassium/recipes/readme.rb
+++ b/lib/potassium/recipes/readme.rb
@@ -1,6 +1,6 @@
-class Recipes::Readme < Recipes::Base
+class Recipes::Readme < Rails::AppBuilder
   def create
-    t.remove_file "README.md"
-    t.template '../assets/README.md.erb', 'README.md'
+    remove_file "README.md"
+    template '../assets/README.md.erb', 'README.md'
   end
 end

--- a/lib/potassium/recipes/ruby.rb
+++ b/lib/potassium/recipes/ruby.rb
@@ -1,11 +1,11 @@
 require 'net/http'
 require 'semantic'
 
-class Recipes::Ruby < Recipes::Base
+class Recipes::Ruby < Rails::AppBuilder
   def create
-    t.info 'Getting platanus latest ruby version...'
-    t.info "Using ruby version #{version_alias}"
-    t.create_file '.ruby-version', version_alias
+    info 'Getting platanus latest ruby version...'
+    info "Using ruby version #{version_alias}"
+    create_file '.ruby-version', version_alias
   end
 
   private

--- a/lib/potassium/recipes/secrets.rb
+++ b/lib/potassium/recipes/secrets.rb
@@ -1,5 +1,5 @@
-class Recipes::Secrets < Recipes::Base
+class Recipes::Secrets < Rails::AppBuilder
   def create
-    t.template '../assets/config/secrets.yml.erb', 'config/secrets.yml', force: true
+    template '../assets/config/secrets.yml.erb', 'config/secrets.yml', force: true
   end
 end

--- a/lib/potassium/recipes/staging.rb
+++ b/lib/potassium/recipes/staging.rb
@@ -1,5 +1,5 @@
-class Recipes::Staging < Recipes::Base
+class Recipes::Staging < Rails::AppBuilder
   def create
-    t.copy_file '../assets/config/environments/staging.rb', "config/environments/staging.rb"
+    copy_file '../assets/config/environments/staging.rb', "config/environments/staging.rb"
   end
 end

--- a/lib/potassium/recipes/style.rb
+++ b/lib/potassium/recipes/style.rb
@@ -1,10 +1,10 @@
-class Recipes::Style < Recipes::Base
+class Recipes::Style < Rails::AppBuilder
   def create
-    t.copy_file '../assets/.rubocop.yml', '.rubocop.yml'
-    t.copy_file '../assets/.ruby_style.yml', '.ruby_style.yml'
-    t.copy_file '../assets/.hound.yml', '.hound.yml'
+    copy_file '../assets/.rubocop.yml', '.rubocop.yml'
+    copy_file '../assets/.ruby_style.yml', '.ruby_style.yml'
+    copy_file '../assets/.hound.yml', '.hound.yml'
 
-    t.append_to_file '.gitignore', '.rubocop-http*\n'
+    append_to_file '.gitignore', '.rubocop-http*\n'
   end
 
   def install

--- a/lib/potassium/recipes/testing.rb
+++ b/lib/potassium/recipes/testing.rb
@@ -1,17 +1,17 @@
-class Recipes::Testing < Recipes::Base
+class Recipes::Testing < Rails::AppBuilder
   def create
-    t.gather_gems(:development, :test) do
+    gather_gems(:development, :test) do
       gather_gem('rspec-rails')
       gather_gem('factory_girl_rails')
       gather_gem('guard-rspec', require: false)
       gather_gem('rspec-nc', require: false)
     end
 
-    t.gather_gems(:test) do
+    gather_gems(:test) do
       gather_gem('shoulda-matchers', require: false)
     end
 
-    t.after(:gem_install) do
+    after(:gem_install) do
       remove_dir 'test'
 
       generate "rspec:install"
@@ -30,7 +30,7 @@ class Recipes::Testing < Recipes::Base
     end
 
     raise_delivery_errors_regexp = /config.action_mailer.raise_delivery_errors = false\n/
-    t.gsub_file 'config/environments/development.rb', raise_delivery_errors_regexp do
+    gsub_file 'config/environments/development.rb', raise_delivery_errors_regexp do
       "config.action_mailer.raise_delivery_errors = true"
     end
   end

--- a/lib/potassium/templates/application.rb
+++ b/lib/potassium/templates/application.rb
@@ -1,11 +1,3 @@
-Dir.entries(File.expand_path('../../recipes', __FILE__)).each do |file_name|
-  if file_name.end_with?('.rb')
-    recipe_name = file_name.gsub('.rb', '')
-    singleton_class.send(:attr_reader, "#{recipe_name}_recipe")
-    instance_variable_set("@#{recipe_name}_recipe", load_recipe(recipe_name))
-  end
-end
-
 set :app_name, @app_name
 set :titleized_app_name, get(:app_name).titleize
 set :underscorized_app_name, get(:app_name).underscore
@@ -17,46 +9,46 @@ run_action(:cleaning) do
 end
 
 run_action(:asking) do
-  database_recipe.ask
-  devise_recipe.ask
-  admin_recipe.ask
-  angular_admin_recipe.ask
-  delayed_job_recipe.ask
-  pundit_recipe.ask
-  i18n_recipe.ask
-  api_recipe.ask
-  paperclip_recipe.ask
-  heroku_recipe.ask
+  ask :database
+  ask :devise
+  ask :admin
+  ask :angular_admin
+  ask :delayed_job
+  ask :pundit
+  ask :i18n
+  ask :api
+  ask :paperclip
+  ask :heroku
 end
 
 run_action(:recipe_loading) do
-  heroku_recipe.create
-  puma_recipe.create
-  database_recipe.create
-  readme_recipe.create
-  ruby_recipe.create
-  env_recipe.create
-  bower_recipe.create
-  editorconfig_recipe.create
-  aws_sdk_recipe.create
-  i18n_recipe.create
-  pry_recipe.create
-  devise_recipe.create
-  admin_recipe.create
-  angular_admin_recipe.create
-  delayed_job_recipe.create
-  pundit_recipe.create
-  testing_recipe.create
-  production_recipe.create
-  staging_recipe.create
-  secrets_recipe.create
-  git_recipe.create
-  api_recipe.create
-  rack_cors_recipe.create
-  ci_recipe.create
-  paperclip_recipe.create
-  style_recipe.create
-  cleanup_recipe.create
+  create :heroku
+  create :puma
+  create :database
+  create :readme
+  create :ruby
+  create :env
+  create :bower
+  create :editorconfig
+  create :aws_sdk
+  create :i18n
+  create :pry
+  create :devise
+  create :admin
+  create :angular_admin
+  create :delayed_job
+  create :pundit
+  create :testing
+  create :production
+  create :staging
+  create :secrets
+  create :git
+  create :api
+  create :rack_cors
+  create :ci
+  create :paperclip
+  create :style
+  create :cleanup
 end
 
 info "Gathered enough information. Applying the template. Wait a minute."

--- a/lib/potassium/templates/recipe.rb
+++ b/lib/potassium/templates/recipe.rb
@@ -1,11 +1,8 @@
 recipe_name = ARGV.first
 
 run_action(:recipe_loading) do
-  recipe = load_recipe(recipe_name)
-  if recipe
-    recipe.install
-    run_action(:gem_install) do
-      run "bundle install" if build_gemfile
-    end
+  install recipe_name.to_sym
+  run_action(:gem_install) do
+    run "bundle install" if build_gemfile
   end
 end


### PR DESCRIPTION
- Simplify the recipes inherinting directly from Rails::AppBuilder that
  give us the template context and all the methods. We don't need to use
  `t.method_name` just `method_name`
- Improve the way the recipes are loaded, we can have now a dsl to call
  create, install and ask making the template cleaner and easier to read