### PR TITLE
move the heroku setup outside the setup script, close #71

### DIFF
--- a/lib/potassium/assets/bin/setup.erb
+++ b/lib/potassium/assets/bin/setup.erb
@@ -17,23 +17,6 @@ bin/rake db:setup
 mkdir -p .git/safe
 
 <% if selected?(:heroku) -%>
-if heroku auth:whoami &> /dev/null; then
-  # Setup heroku application remotes
-  if heroku apps:info --app <%= get(:heroku_app_name_staging) %> &> /dev/null; then
-    git remote add staging git@heroku.com:<%= get(:heroku_app_name_staging) %>.git || true
-    git config heroku.remote staging
-    echo 'You are a collaborator on the "<%= get(:heroku_app_name_staging) %>" Heroku app'
-  else
-    echo 'Ask for access to the "<%= get(:heroku_app_name_staging) %>" Heroku app'
-  fi
-
-  if heroku apps:info --app <%= get(:heroku_app_name_production) %> &> /dev/null; then
-    git remote add production git@heroku.com:<%= get(:heroku_app_name_production) %>.git || true
-    echo 'You are a collaborator on the "<%= get(:heroku_app_name_production) %>" Heroku app'
-  else
-    echo 'Ask for access to the "<%= get(:heroku_app_name_production) %>" Heroku app'
-  fi
-else
-  echo 'You need to login to heroku. Run "heroku login"'
-fi
+# Setup heroku remotes
+bin/setup_heroku
 <% end-%>

--- a/lib/potassium/assets/bin/setup_heroku.erb
+++ b/lib/potassium/assets/bin/setup_heroku.erb
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Setup heroku application remotes
+if heroku auth:whoami &> /dev/null; then
+  if heroku apps:info --app <%= get(:heroku_app_name_staging) %> &> /dev/null; then
+    git remote add staging git@heroku.com:<%= get(:heroku_app_name_staging) %>.git || true
+    git config heroku.remote staging
+    echo 'You are a collaborator on the "<%= get(:heroku_app_name_staging) %>" Heroku app'
+  else
+    echo 'Ask for access to the "<%= get(:heroku_app_name_staging) %>" Heroku app'
+  fi
+
+  if heroku apps:info --app <%= get(:heroku_app_name_production) %> &> /dev/null; then
+    git remote add production git@heroku.com:<%= get(:heroku_app_name_production) %>.git || true
+    echo 'You are a collaborator on the "<%= get(:heroku_app_name_production) %>" Heroku app'
+  else
+    echo 'Ask for access to the "<%= get(:heroku_app_name_production) %>" Heroku app'
+  fi
+else
+  echo 'You need to login to heroku. Run "heroku login"'
+fi

--- a/lib/potassium/recipes/heroku.rb
+++ b/lib/potassium/recipes/heroku.rb
@@ -41,6 +41,9 @@ class Recipes::Heroku < Rails::AppBuilder
     copy_file '../assets/Procfile', 'Procfile'
     copy_file '../assets/.buildpacks', '.buildpacks'
 
+    template "../assets/bin/setup_heroku.erb", "bin/setup_heroku", force: true
+    run "chmod a+x bin/setup_heroku"
+
     if logged_in?
       %w(staging production).each do |environment|
         create_app_on_heroku(environment)

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -48,9 +48,14 @@ RSpec.describe "Heroku" do
     bin_setup_path = "#{project_path}/bin/setup"
     bin_setup = IO.read(bin_setup_path)
 
-    expect(bin_setup).to include("heroku apps:info --app pl-#{app_name}-staging")
-    expect(bin_setup).to include("heroku apps:info --app pl-#{app_name}-production")
-    expect(bin_setup).to include("git config heroku.remote staging")
+    expect(bin_setup).to include("bin/setup_heroku")
+
+    bin_setup_heroku_path = "#{project_path}/bin/setup_heroku"
+    bin_setup_heroku = IO.read(bin_setup_heroku_path)
+
+    expect(bin_setup_heroku).to include("heroku apps:info --app pl-#{app_name}-staging")
+    expect(bin_setup_heroku).to include("heroku apps:info --app pl-#{app_name}-production")
+    expect(bin_setup_heroku).to include("git config heroku.remote staging")
     expect(File.stat(bin_setup_path)).to be_executable
   end
 end


### PR DESCRIPTION
The setup script will run the heroku setup script. But now the user can run the heroku setup independently. This close the issue #71 by not having to run the setup script when the project already exists