### PR TITLE
remote checking for heroku pipelines

### DIFF
--- a/lib/potassium/recipes/heroku.rb
+++ b/lib/potassium/recipes/heroku.rb
@@ -107,12 +107,6 @@ class Recipes::Heroku < Rails::AppBuilder
   end
 
   def add_app_to_pipeline(app_env_name, environment)
-    pipelines_plugin = `heroku plugins | grep pipelines`
-    if pipelines_plugin.empty?
-      puts "You need heroku pipelines plugin. Run: heroku plugins:install heroku-pipelines"
-      exit 1
-    end
-
     pipeline = `heroku pipelines:info \
       #{heroku_pipeline_name} 2>/dev/null | grep #{heroku_pipeline_name}`
     pipeline_command = pipeline.empty? ? "create" : "add"

--- a/spec/support/fake_heroku.rb
+++ b/spec/support/fake_heroku.rb
@@ -8,9 +8,7 @@ class FakeHeroku
   end
 
   def run!
-    if @args.first == "plugins"
-      puts "heroku-pipelines@0.29.0"
-    elsif @args.first == "pipelines:info"
+    if @args.first == "pipelines:info"
       if FakeHeroku.has_created_pipeline?
         puts "=== dummy-app\nstaging:\tpl-dummy-app-staging\nproduction:\tpl-dummy-app-production"
       end


### PR DESCRIPTION
the heroku pipelines are now a core part of the heroku cli, there is no need to add a plugin. We can assume the pipelines command will be there for us