### PR TITLE
remove staging environment

### DIFF
--- a/lib/potassium/assets/config/database_mysql.yml.erb
+++ b/lib/potassium/assets/config/database_mysql.yml.erb
@@ -21,5 +21,3 @@ production: &deploy
   pool: <%%= [Integer(ENV.fetch("MAX_THREADS", 5)), Integer(ENV.fetch("DB_POOL", 5))].max %>
   timeout: 5000
   url: <%%= ENV.fetch("DATABASE_URL", "") %>
-
-staging: *deploy

--- a/lib/potassium/assets/config/database_postgresql.yml.erb
+++ b/lib/potassium/assets/config/database_postgresql.yml.erb
@@ -21,5 +21,3 @@ production: &deploy
   pool: <%%= [Integer(ENV.fetch("MAX_THREADS", 5)), Integer(ENV.fetch("DB_POOL", 5))].max %>
   timeout: 5000
   url: <%%= ENV.fetch("DATABASE_URL", "") %>
-
-staging: *deploy

--- a/lib/potassium/assets/config/environments/staging.rb
+++ b/lib/potassium/assets/config/environments/staging.rb
@@ -1,5 +1,0 @@
-require_relative "production"
-
-Rails.application.configure do
-  # ...
-end

--- a/lib/potassium/assets/config/secrets.yml.erb
+++ b/lib/potassium/assets/config/secrets.yml.erb
@@ -7,8 +7,5 @@ development:
 test:
   <<: *default
 
-staging:
-  <<: *default
-
 production:
   <<: *default

--- a/lib/potassium/recipes/cleanup.rb
+++ b/lib/potassium/recipes/cleanup.rb
@@ -2,7 +2,6 @@ class Recipes::Cleanup < Rails::AppBuilder
   def create
     erase_comments "config/application.rb"
     erase_comments "config/environments/production.rb"
-    erase_comments "config/environments/staging.rb"
     erase_comments "config/environments/test.rb"
     erase_comments "config/environments/development.rb"
     cut_comments "config/initializers/backtrace_silencers.rb", limit: 100

--- a/lib/potassium/recipes/heroku.rb
+++ b/lib/potassium/recipes/heroku.rb
@@ -34,7 +34,7 @@ class Recipes::Heroku < Rails::AppBuilder
   private
 
   def add_heroku
-    gather_gems(:production, :staging) do
+    gather_gems(:production) do
       gather_gem('rails_stdout_logging')
     end
 
@@ -80,7 +80,7 @@ class Recipes::Heroku < Rails::AppBuilder
   end
 
   def create_app_on_heroku(environment)
-    rack_env = "RACK_ENV=#{environment} RAILS_ENV=#{environment}"
+    rack_env = "RACK_ENV=production RAILS_ENV=production"
     staged_app_name = app_name_for(environment)
 
     run_toolbelt_command "create #{staged_app_name} --remote #{environment}"

--- a/lib/potassium/recipes/puma.rb
+++ b/lib/potassium/recipes/puma.rb
@@ -2,7 +2,7 @@ class Recipes::Puma < Rails::AppBuilder
   def create
     gather_gem 'puma'
 
-    gather_gems(:production, :staging) do
+    gather_gems(:production) do
       gather_gem 'rack-timeout'
     end
 

--- a/lib/potassium/recipes/staging.rb
+++ b/lib/potassium/recipes/staging.rb
@@ -1,5 +1,0 @@
-class Recipes::Staging < Rails::AppBuilder
-  def create
-    copy_file '../assets/config/environments/staging.rb', "config/environments/staging.rb"
-  end
-end

--- a/lib/potassium/templates/application.rb
+++ b/lib/potassium/templates/application.rb
@@ -44,7 +44,6 @@ run_action(:recipe_loading) do
   create :pundit
   create :testing
   create :production
-  create :staging
   create :secrets
   create :git
   create :api


### PR DESCRIPTION
We should use production environment in staging servers, that way we encourage the staging-production parity, close #87 