### PR TITLE
remove RAILS_ENV

### DIFF
--- a/lib/potassium/assets/config/puma.rb
+++ b/lib/potassium/assets/config/puma.rb
@@ -20,7 +20,7 @@ preload_app!
 
 rackup DefaultRackup
 port ENV.fetch('PORT', 3000)
-environment ENV.fetch("RAILS_ENV", "development")
+environment ENV.fetch("RACK_ENV", "development")
 
 on_worker_boot do
   # Worker specific setup for Rails 4.1+

--- a/lib/potassium/assets/docker-compose.ci.yml
+++ b/lib/potassium/assets/docker-compose.ci.yml
@@ -6,4 +6,4 @@ test:
     - ./vendor/bundle:/usr/local/bundle
     - $CIRCLE_TEST_REPORTS/rspec:$HOME/.rspec_reports
   environment:
-    RAILS_ENV: test
+    RACK_ENV: test

--- a/lib/potassium/assets/testing/rails_helper.rb
+++ b/lib/potassium/assets/testing/rails_helper.rb
@@ -1,5 +1,5 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV['RAILS_ENV'] ||= 'test'
+ENV['RACK_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 require 'spec_helper'

--- a/lib/potassium/recipes/heroku.rb
+++ b/lib/potassium/recipes/heroku.rb
@@ -80,7 +80,7 @@ class Recipes::Heroku < Rails::AppBuilder
   end
 
   def create_app_on_heroku(environment)
-    rack_env = "RACK_ENV=production RAILS_ENV=production"
+    rack_env = "RACK_ENV=production"
     staged_app_name = app_name_for(environment)
 
     run_toolbelt_command "create #{staged_app_name} --remote #{environment}"

--- a/lib/potassium/templates/application.rb
+++ b/lib/potassium/templates/application.rb
@@ -63,5 +63,5 @@ end
 
 run_action(:database_creation) do
   run "rake db:create db:migrate"
-  run "RAILS_ENV=test rake db:create db:migrate"
+  run "RACK_ENV=test rake db:create db:migrate"
 end

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -34,12 +34,10 @@ RSpec.describe "Heroku" do
 
     expect(FakeHeroku).to have_configured_vars("staging", "SECRET_KEY_BASE")
     expect(FakeHeroku).to have_configured_vars("staging", "RACK_ENV")
-    expect(FakeHeroku).to have_configured_vars("staging", "RAILS_ENV")
     expect(FakeHeroku).to have_configured_vars("staging", "DEPLOY_TASKS")
 
     expect(FakeHeroku).to have_configured_vars("production", "SECRET_KEY_BASE")
     expect(FakeHeroku).to have_configured_vars("production", "RACK_ENV")
-    expect(FakeHeroku).to have_configured_vars("production", "RAILS_ENV")
     expect(FakeHeroku).to have_configured_vars("production", "DEPLOY_TASKS")
 
     expect(FakeHeroku).to have_created_pipeline_for("staging")


### PR DESCRIPTION
To avoid duplication, with should rely on RACK_ENV as Rails.env ask for RAILS_ENV and then fallback to RACK_ENV