### PR TITLE
Add tzinfo-data

### DIFF
--- a/lib/potassium/recipes/tzinfo.rb
+++ b/lib/potassium/recipes/tzinfo.rb
@@ -1,0 +1,7 @@
+class Recipes::Tzinfo < Rails::AppBuilder
+  def create
+    gather_gems(:production, :development, :test) do
+      gather_gem("tzinfo-data")
+    end
+  end
+end

--- a/lib/potassium/templates/application.rb
+++ b/lib/potassium/templates/application.rb
@@ -49,6 +49,7 @@ run_action(:recipe_loading) do
   create :api
   create :rack_cors
   create :paperclip
+  create :tzinfo
   create :script
   create :github
   create :cleanup


### PR DESCRIPTION
Adds `tzinfo-data` gem to help ActiveSupport resolve timezones consistently.