### PR TITLE
feat(mailer): config development environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Configure mailer for development environment
 - Configure Rspec to work with Paperclip
 - Update [multi buildpack]([multi-buildpack-heroku]) buildback to the heroku version
 - Update ruby version on CI docker image

--- a/lib/potassium/recipes/delayed_job.rb
+++ b/lib/potassium/recipes/delayed_job.rb
@@ -23,8 +23,10 @@ class Recipes::DelayedJob < Rails::AppBuilder
   def add_delayed_job
     gather_gem "delayed_job_active_record"
 
-    delayed_job_config = "config.active_job.queue_adapter = :delayed_job"
-    application(delayed_job_config)
+    general_config = "config.active_job.queue_adapter = :delayed_job"
+    application(general_config)
+    dev_config = "config.active_job.queue_adapter = :inline"
+    application dev_config, env: "development"
 
     after(:gem_install) do
       generate "delayed_job:active_record"
@@ -32,9 +34,7 @@ class Recipes::DelayedJob < Rails::AppBuilder
       add_readme_section :internal_dependencies, :delayed_job
 
       if selected?(:heroku)
-        gsub_file "Procfile", /^.*$/m do |match|
-          "#{match}worker: bundle exec rake jobs:work"
-        end
+        gsub_file("Procfile", /^.*$/m) { |match| "#{match}worker: bundle exec rake jobs:work" }
       end
     end
   end

--- a/lib/potassium/recipes/mailer.rb
+++ b/lib/potassium/recipes/mailer.rb
@@ -91,5 +91,7 @@ class Recipes::Mailer < Rails::AppBuilder
   end
 
   def aws_ses
+    gather_gems(:development) { gather_gem("letter_opener") }
+    application "config.action_mailer.delivery_method = :letter_opener", env: "development"
   end
 end


### PR DESCRIPTION
- Agregué `config.active_job.queue_adapter = :inline` a development
- Hice que si se se selecciona SES para enviar mails, en development se use letter_opener. En el caso de sendgrid no se puede porque al no tener los templates en rails, al cambiar el adapter a letter_opener, da este error: `ActionView::MissingTemplate: Missing`