### PR TITLE
chore(gems): quiet_assets and better_errors gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 - Add draper gem to decorate models
 
+## 3.0.0
+
+Features:
+  - Rails 5.0.2
+  - `better_errors` and `binding_of_caller` gem in development
+  - Update `aws_sdk` to `~> 2.5`
+  - Update `paperclip` to `~> 5,0`
+
 ## 2.3.0
 
 Features:

--- a/lib/potassium/recipes/better_errors.rb
+++ b/lib/potassium/recipes/better_errors.rb
@@ -1,0 +1,8 @@
+class Recipes::BetterErrors < Rails::AppBuilder
+  def create
+    gather_gems(:development, :test) do
+      gather_gem('better_errors')
+      gather_gem('binding_of_caller')
+    end
+  end
+end

--- a/lib/potassium/recipes/quiet_assets.rb
+++ b/lib/potassium/recipes/quiet_assets.rb
@@ -1,7 +1,0 @@
-class Recipes::QuietAssets < Rails::AppBuilder
-  def create
-    gather_gems(:development, :test) do
-      gather_gem('quiet_assets')
-    end
-  end
-end

--- a/lib/potassium/recipes/quiet_assets.rb
+++ b/lib/potassium/recipes/quiet_assets.rb
@@ -1,0 +1,7 @@
+class Recipes::QuietAssets < Rails::AppBuilder
+  def create
+    gather_gems(:development, :test) do
+      gather_gem('quiet_assets')
+    end
+  end
+end

--- a/lib/potassium/templates/application.rb
+++ b/lib/potassium/templates/application.rb
@@ -47,7 +47,6 @@ run_action(:recipe_loading) do
   create :mailer
   create :i18n
   create :pry
-  create :quiet_assets
   create :better_errors
   create :devise
   create :admin

--- a/lib/potassium/templates/application.rb
+++ b/lib/potassium/templates/application.rb
@@ -47,6 +47,8 @@ run_action(:recipe_loading) do
   create :mailer
   create :i18n
   create :pry
+  create :quiet_assets
+  create :better_errors
   create :devise
   create :admin
   create :angular_admin

--- a/lib/potassium/version.rb
+++ b/lib/potassium/version.rb
@@ -1,6 +1,6 @@
 module Potassium
   VERSION = "2.3.0"
   RUBY_VERSION = "2.3.1"
-  RAILS_VERSION = "~> 5.0.1"
+  RAILS_VERSION = "~> 5.0.2"
   RUBOCOP_VERSION = "~> 0.46.0"
 end


### PR DESCRIPTION
Estas gemas para desarrollo son muy cómodas. Quiet assets hace que la consola no escriba tanta cosa y better errors cambia la pantalla de error por una mas usable. Además binding of caller, entrega una pequeña consola para depurar estilo pry.