### PR TITLE
remove heroku dependency from mailer recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Remove heroku dependency from mailer recipe, #124
 
 ## 3.0.0
 

--- a/lib/potassium/assets/config/mailer.rb.erb
+++ b/lib/potassium/assets/config/mailer.rb.erb
@@ -13,6 +13,6 @@ Rails.application.config.action_mailer.asset_host = ASSET_HOST
 if ENV["EMAIL_RECIPIENTS"].present?
   Mail.register_interceptor RecipientInterceptor.new(
     ENV["EMAIL_RECIPIENTS"],
-    subject_prefix: "[#{Heroku.stage.upcase}]"
+    subject_prefix: "[<%= get(:heroku) ? '#{Heroku.stage.upcase}' : '#{Rails.env}' %>]"
   )
 end

--- a/lib/potassium/recipes/heroku.rb
+++ b/lib/potassium/recipes/heroku.rb
@@ -36,9 +36,8 @@ class Recipes::Heroku < Rails::AppBuilder
   def add_heroku
     gather_gems(:production) do
       gather_gem('rails_stdout_logging')
+      gather_gem('heroku-stage')
     end
-
-    gather_gem 'heroku-stage'
 
     copy_file '../assets/Procfile', 'Procfile'
     copy_file '../assets/.buildpacks', '.buildpacks'

--- a/lib/potassium/recipes/mailer.rb
+++ b/lib/potassium/recipes/mailer.rb
@@ -58,12 +58,11 @@ class Recipes::Mailer < Rails::AppBuilder
     else
       gather_gem service[:gem_name]
     end
-    gather_gem 'heroku-stage'
     gather_gem 'recipient_interceptor'
   end
 
   def config(service)
-    template "../assets/config/mailer.rb", 'config/mailer.rb'
+    template "../assets/config/mailer.rb.erb", 'config/mailer.rb'
     gsub_file 'config/environments/production.rb', /$\s*config.action_mailer.*/, ''
     append_to_file '.env.development', "APPLICATION_HOST=localhost:3000\n"
     append_to_file '.env.development', "EMAIL_RECIPIENTS=\n"


### PR DESCRIPTION
Move heroku stage to production only and us it in the mailer recipe only if heroku is being used