### PR TITLE
fix(schedule): recipe check using regex

### DIFF
--- a/lib/potassium/recipes/schedule.rb
+++ b/lib/potassium/recipes/schedule.rb
@@ -20,6 +20,6 @@ class Recipes::Schedule < Rails::AppBuilder
   end
 
   def installed?
-    gem_exists?("sidekiq-scheduler") && file_exist?('config/sidekiq.yml')
+    gem_exists?(/sidekiq-scheduler/) && file_exist?('config/sidekiq.yml')
   end
 end


### PR DESCRIPTION
This was failing because we were checking the existence of the sidekiq-scheduler gem using a string instead of a regex.