### PR TITLE
fix(config): remove production database url default value

### DIFF
--- a/lib/potassium/assets/config/database_mysql.yml.erb
+++ b/lib/potassium/assets/config/database_mysql.yml.erb
@@ -19,4 +19,4 @@ production: &deploy
   min_messages: warning
   pool: <%%= [Integer(ENV.fetch("MAX_THREADS", 5)), Integer(ENV.fetch("DB_POOL", 5))].max %>
   timeout: 5000
-  url: <%%= ENV.fetch("DATABASE_URL", "") %>
+  url: <%%= ENV.fetch("DATABASE_URL") %>

--- a/lib/potassium/assets/config/database_postgresql.yml.erb
+++ b/lib/potassium/assets/config/database_postgresql.yml.erb
@@ -19,4 +19,4 @@ production: &deploy
   min_messages: warning
   pool: <%%= [Integer(ENV.fetch("MAX_THREADS", 5)), Integer(ENV.fetch("DB_POOL", 5))].max %>
   timeout: 5000
-  url: <%%= ENV.fetch("DATABASE_URL", "") %>
+  url: <%%= ENV.fetch("DATABASE_URL") %>


### PR DESCRIPTION
La `url` de la base de datos de producción debe existir en el yml de la configuración. Es por lo anterior que dejar como _default_ un string vacío no es conveniente ya que en caso de que esta variable no sea ingresada, será difícil reconocer de dónde viene el problema. Este PR remueve el valor por defecto para que la aplicación lance una excepción en caso de que esta variable falte.