### PR TITLE
fix(puma): set 1 day timeout for puma workers on development

### DIFF
--- a/lib/potassium/assets/config/puma.rb
+++ b/lib/potassium/assets/config/puma.rb
@@ -20,7 +20,11 @@ preload_app!
 
 rackup DefaultRackup
 port ENV.fetch('PORT', 3000)
-environment ENV.fetch("RACK_ENV", "development")
+rack_env = ENV.fetch("RACK_ENV", "development")
+environment rack_env
+
+# Set 1 day timeout for workers while developing
+worker_timeout 1.day.seconds.to_i if rack_env == "development"
 
 on_worker_boot do
   # Worker specific setup for Rails 4.1+


### PR DESCRIPTION
This PR sets 1 day timeout for puma workers on development.

This enables long `binding.pry` debugs without losing all the context due to puma restarting the process.

👍 