### PR TITLE
5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
-## Unreleased
+## 5.2.1
+
+Features:
+  - Databases are now provided as docker containers
+
+Changes:
+  - Update postgres to 11
+  - Update mysql to 5.7
+  - Update rubocop to `~> 0.65.0`
+  - Puma worker timeout is extended to 1 day in development env
+  - Spring is loaded only in development env
+  - Remove version requirement for `pg`
+
+Fix:
+  - Update mysql2 to `~> 0.5.0` (required for rails 5+)
+  - Use `RACK_TIMEOUT` env var instead deprecated setter
 
 ## 5.2.0
 

--- a/lib/potassium/version.rb
+++ b/lib/potassium/version.rb
@@ -1,5 +1,5 @@
 module Potassium
-  VERSION = "5.2.0"
+  VERSION = "5.2.1"
   RUBY_VERSION = "2.5.5"
   RAILS_VERSION = "~> 5.2.1"
   RUBOCOP_VERSION = "~> 0.65.0"

--- a/lib/potassium/version.rb
+++ b/lib/potassium/version.rb
@@ -1,6 +1,6 @@
 module Potassium
   VERSION = "5.2.0"
-  RUBY_VERSION = "2.5"
+  RUBY_VERSION = "2.5.5"
   RAILS_VERSION = "~> 5.2.1"
   RUBOCOP_VERSION = "~> 0.65.0"
   POSTGRES_VERSION = "11.3"


### PR DESCRIPTION
- Fixes a bug introduced since `ruby` recipe needs a full semantic ruby version
- Version bump to 5.2.1
