### PR TITLE
fix(ci): update database env vars with database_container vars

### DIFF
--- a/lib/potassium/assets/bin/cibuild.erb
+++ b/lib/potassium/assets/bin/cibuild.erb
@@ -22,7 +22,7 @@ wait_services(){
   # Chain tests together by using &&
   until (
   <% if(selected?(:database, :mysql) || selected?(:database, :postgresql))-%>
-  test_service '$<%=get(:database).to_s.upcase%>_HOST' '$<%=get(:database).to_s.upcase%>_PORT' && \
+  test_service '$DB_HOST' '$DB_PORT' && \
   <% end-%>
   echo "Services ready"
   )

--- a/lib/potassium/recipes/ci.rb
+++ b/lib/potassium/recipes/ci.rb
@@ -36,9 +36,9 @@ class Recipes::Ci < Rails::AppBuilder
         YAML
       compose.add_service("postgresql", srv)
       compose.add_link('test', 'postgresql')
-      compose.add_env('test', 'POSTGRESQL_USER', 'postgres')
-      compose.add_env('test', 'POSTGRESQL_HOST', 'postgresql')
-      compose.add_env('test', 'POSTGRESQL_PORT', '5432')
+      compose.add_env('test', 'DB_USER', 'postgres')
+      compose.add_env('test', 'DB_HOST', 'postgresql')
+      compose.add_env('test', 'DB_PORT', '5432')
     end
 
     add_readme_header :ci


### PR DESCRIPTION
## Description

After creating a new repo using `database_container` recipe, the CI env is broken because the `database.yml` file no longer uses `POSTGRESQL_*` env vars.

## Changes

- Use `DB_*` env vars in `cibuild` and `docker-compose.ci.yml` files