### PR TITLE
Sendgrid dev

### DIFF
--- a/lib/potassium/recipes/mailer.rb
+++ b/lib/potassium/recipes/mailer.rb
@@ -86,6 +86,13 @@ class Recipes::Mailer < Rails::AppBuilder
     RUBY
     inject_into_file 'config/mailer.rb', sendgrid_settings,
       after: "Rails.application.config.action_mailer.delivery_method = :sendgrid\n"
+    sendgrid_dev_settings = <<~RUBY
+      Rails.application.config.action_mailer.sendgrid_dev_settings = {
+        api_key: ENV['SENDGRID_API_KEY']
+      }
+    RUBY
+    application sendgrid_dev_settings, env: "development"
+    application "config.action_mailer.delivery_method = :sendgrid_dev", env: "development"
   end
 
   def aws_ses

--- a/lib/potassium/recipes/mailer.rb
+++ b/lib/potassium/recipes/mailer.rb
@@ -81,7 +81,7 @@ class Recipes::Mailer < Rails::AppBuilder
     append_to_file '.env.development', "SENDGRID_API_KEY=\n"
     sendgrid_settings = <<~RUBY
       Rails.application.config.action_mailer.sendgrid_settings = {
-        api_key: ENV['SENDGRID_API']
+        api_key: ENV['SENDGRID_API_KEY']
       }
     RUBY
     inject_into_file 'config/mailer.rb', sendgrid_settings,

--- a/spec/features/mailer_spec.rb
+++ b/spec/features/mailer_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+RSpec.describe "Mailer" do
+  let(:gemfile) { IO.read("#{project_path}/Gemfile") }
+  let(:mailer_config) { IO.read("#{project_path}/config/mailer.rb") }
+  let(:dev_config) { IO.read("#{project_path}/config/environments/development.rb") }
+
+  before(:all) { drop_dummy_database }
+
+  context "when selecting sendgrid as mailer" do
+    before(:all) do
+      remove_project_directory
+      create_dummy_project("email_service" => "sendgrid")
+    end
+
+    it { expect(gemfile).to include("send_grid_mailer") }
+
+    it "adds configuration to mailer.rb" do
+      expect(mailer_config).to include("delivery_method = :sendgrid")
+      expect(mailer_config).to include("sendgrid_settings = {")
+      expect(mailer_config).to include("api_key: ENV['SENDGRID_API_KEY']")
+    end
+
+    it "adds configuration to development.rb" do
+      expect(dev_config).to include("delivery_method = :sendgrid_dev")
+      expect(dev_config).to include("sendgrid_dev_settings = {")
+      expect(dev_config).to include("api_key: ENV['SENDGRID_API_KEY']")
+    end
+  end
+
+  context "when selecting aws_ses as mailer" do
+    before(:all) do
+      remove_project_directory
+      create_dummy_project("email_service" => "aws_ses")
+    end
+
+    it { expect(gemfile).to include("aws-sdk-rails") }
+    it { expect(gemfile).to include("letter_opener") }
+    it { expect(mailer_config).to include("delivery_method = :aws_sdk") }
+    it { expect(dev_config).to include("delivery_method = :letter_opener") }
+  end
+end


### PR DESCRIPTION
- Fixes call to `ENV['SENDGRID_API']`, should've been `SENDGRID_API_KEY`
- Adds configuration to `development.rb` to use `sendgrid_dev` as delivery method whe user selects `sendgrid` as mailer
- Adds missing mailer tests