### PR TITLE
fix(database-container): make install option work

### DIFF
--- a/lib/potassium/recipes/database_container.rb
+++ b/lib/potassium/recipes/database_container.rb
@@ -24,7 +24,7 @@ class Recipes::DatabaseContainer < Rails::AppBuilder
       environment:
         MYSQL_ALLOW_EMPTY_PASSWORD: 'true'
       volumes:
-       - mysql_data:/var/lib/mysql
+        - mysql_data:/var/lib/mysql
     YAML
 
   def create
@@ -58,6 +58,7 @@ class Recipes::DatabaseContainer < Rails::AppBuilder
       TEXT
 
     insert_into_file 'bin/setup', setup_text, before: "# Set up database"
+    create
     run 'bin/setup'
     info "A new container with a #{get(:database)} database has been created."
   end


### PR DESCRIPTION
Call to `create` method was missing when installing the recipe `database_container`, resulting in missing necessary files to run a database container on legacy projects.