### PR TITLE
Test env teardown

### DIFF
--- a/lib/potassium/assets/bin/cibuild.erb
+++ b/lib/potassium/assets/bin/cibuild.erb
@@ -15,7 +15,7 @@ build(){
 # Wait services to be ready
 wait_services(){
   function test_service {
-    docker-compose $DOCKER_COMPOSE_ARGS run test sh -c "nc -z $1 $2"
+    docker-compose $DOCKER_COMPOSE_ARGS run --rm test sh -c "nc -z $1 $2"
   }
 
   count=0
@@ -41,16 +41,16 @@ wait_services(){
 
 # Prepare dependencies
 dependencies(){
-  docker-compose $DOCKER_COMPOSE_ARGS run test bundle install
+  docker-compose $DOCKER_COMPOSE_ARGS run --rm test bundle install
 }
 
 assets() {
-  docker-compose $DOCKER_COMPOSE_ARGS run test /bin/bash -c "bin/setup && bundle exec rake assets:precompile"
+  docker-compose $DOCKER_COMPOSE_ARGS run --rm test /bin/bash -c "bin/setup && bundle exec rake assets:precompile"
 }
 
 # Prepare database
 database(){
-  docker-compose $DOCKER_COMPOSE_ARGS run test bundle exec rake db:create db:schema:load
+  docker-compose $DOCKER_COMPOSE_ARGS run --rm test bundle exec rake db:create db:schema:load
 }
 
 # Run the specs
@@ -59,7 +59,7 @@ tests(){
     RSPEC_JUNIT_ARGS="-r rspec_junit_formatter --format RspecJunitFormatter -o $HOME/.rspec_reports/junit.xml"
     RSPEC_FORMAT_ARGS="--format progress --no-color"
   }
-  docker-compose $DOCKER_COMPOSE_ARGS run test bundle exec rspec spec $RSPEC_FORMAT_ARGS $RSPEC_JUNIT_ARGS
+  docker-compose $DOCKER_COMPOSE_ARGS run --rm test bundle exec rspec spec $RSPEC_FORMAT_ARGS $RSPEC_JUNIT_ARGS
 }
 
 # Run the complete ci build

--- a/spec/features/database_container_spec.rb
+++ b/spec/features/database_container_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe "DatabaseContainer" do
     create_dummy_project("database" => database)
   end
 
-  after do
-    `docker-compose -f #{project_path}/docker-compose.yml down`
-  end
-
   [:postgresql, :mysql].each do |db_type|
     context "when database is #{db_type}" do
       let!(:database) { db_type }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,10 @@ RSpec.configure do |config|
     create_tmp_directory
   end
 
+  config.after(:each) do
+    docker_cleanup
+  end
+
   config.before(:each) do
     FakeGithub.clear!
     FakeHeroku.clear!

--- a/spec/support/potassium_test_helpers.rb
+++ b/spec/support/potassium_test_helpers.rb
@@ -47,6 +47,10 @@ module PotassiumTestHelpers
     end
   end
 
+  def docker_cleanup
+    run_command(`docker-compose -f #{project_path}/docker-compose.yml down --volumes`)
+  end
+
   private
 
   def tmp_path


### PR DESCRIPTION
Cleanup docker environment after running tests

### Changes
- Use new test helper to run `docker-compose down` after each test
- Remove command in after block database_container
- Remove one-off containers used in `cibuild`

Fixes #210 