### PR TITLE
fix(gemspec): add rubocop-rspec for compatibility with updated linters

### DIFF
--- a/potassium.gemspec
+++ b/potassium.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.4.0"
   spec.add_development_dependency "pry", "~> 0.10.3"
   spec.add_development_dependency "rubocop", Potassium::RUBOCOP_VERSION
+  spec.add_development_dependency "rubocop-rspec"
   spec.add_runtime_dependency "rails", Potassium::RAILS_VERSION
   spec.add_runtime_dependency "gli", "~> 2.12.2"
   spec.add_runtime_dependency "inquirer", "~> 0.2"


### PR DESCRIPTION
Because of the addition of `rubocop-rspec` to platanus linters in https://github.com/platanus/la-guia/pull/112 , the rubocop spec in potassium was broken.

This PR adds the needed dependency.