### PR TITLE
Remove unnecesary aws-sdk gems

### DIFF
--- a/lib/potassium/assets/aws.rb
+++ b/lib/potassium/assets/aws.rb
@@ -1,1 +1,0 @@
-Aws::VERSION = Gem.loaded_specs["aws-sdk"].version

--- a/lib/potassium/recipes/aws_sdk.rb
+++ b/lib/potassium/recipes/aws_sdk.rb
@@ -1,5 +1,0 @@
-class Recipes::AwsSdk < Rails::AppBuilder
-  def create
-    gather_gem('aws-sdk', '~> 3')
-  end
-end

--- a/lib/potassium/recipes/aws_sdk.rb
+++ b/lib/potassium/recipes/aws_sdk.rb
@@ -1,7 +1,5 @@
 class Recipes::AwsSdk < Rails::AppBuilder
   def create
     gather_gem('aws-sdk', '~> 3')
-
-    template("../assets/aws.rb", "config/initializers/aws.rb", force: true)
   end
 end

--- a/lib/potassium/recipes/file_storage.rb
+++ b/lib/potassium/recipes/file_storage.rb
@@ -63,6 +63,7 @@ class Recipes::FileStorage < Rails::AppBuilder
   end
 
   def common_setup
+    gather_gem 'aws-sdk-s3', '~> 1.0'
     add_readme_section :internal_dependencies, get(:storage)
     append_to_file '.env.development', "S3_BUCKET=\n"
   end

--- a/lib/potassium/recipes/file_storage.rb
+++ b/lib/potassium/recipes/file_storage.rb
@@ -48,7 +48,7 @@ class Recipes::FileStorage < Rails::AppBuilder
   end
 
   def add_paperclip
-    gather_gem 'paperclip', '~> 5.0'
+    gather_gem 'paperclip', '~> 6.0'
     application paperclip_config, env: 'production'
     append_to_file '.gitignore', "/public/system/*\n"
   end

--- a/lib/potassium/templates/application.rb
+++ b/lib/potassium/templates/application.rb
@@ -49,7 +49,6 @@ run_action(:recipe_loading) do
   create :ruby
   create :yarn
   create :editorconfig
-  create :aws_sdk
   create :mailer
   create :background_processor
   create :schedule

--- a/spec/features/file_storage_spec.rb
+++ b/spec/features/file_storage_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe "File Storage" do
       create_dummy_project(storage: :active_storage)
     end
 
+    it "adds the aws-sdk-s3 gem to Gemfile" do
+      gemfile_content = IO.read("#{project_path}/Gemfile")
+      expect(gemfile_content).to include("gem 'aws-sdk-s3'")
+    end
+
     it "customizes config file" do
       content = IO.read("#{project_path}/config/storage.yml")
       expect(content).to include("bucket: <%= ENV['S3_BUCKET'] %>")
@@ -39,6 +44,11 @@ RSpec.describe "File Storage" do
     it "adds the Paperclip gem to Gemfile" do
       gemfile_content = IO.read("#{project_path}/Gemfile")
       expect(gemfile_content).to include("gem 'paperclip'")
+    end
+
+    it "adds the aws-sdk-s3 gem to Gemfile" do
+      gemfile_content = IO.read("#{project_path}/Gemfile")
+      expect(gemfile_content).to include("gem 'aws-sdk-s3'")
     end
 
     it "adds brief to README file" do

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -29,9 +29,6 @@ RSpec.describe "A new project" do
   it "configures aws" do
     gemfile_content = IO.read("#{project_path}/Gemfile")
     expect(gemfile_content).to include("'aws-sdk', '~> 3'")
-
-    initializer = IO.read("#{project_path}/config/initializers/aws.rb")
-    expect(initializer).to include("Aws::VERSION")
   end
 
   it "configures the correct ruby version" do

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -26,11 +26,6 @@ RSpec.describe "A new project" do
     expect(gemfile).to include %{gem 'pg'}
   end
 
-  it "configures aws" do
-    gemfile_content = IO.read("#{project_path}/Gemfile")
-    expect(gemfile_content).to include("'aws-sdk', '~> 3'")
-  end
-
   it "configures the correct ruby version" do
     ruby_version_file = IO.read("#{project_path}/.ruby-version")
 


### PR DESCRIPTION
This PR removes the gem `aws-sdk` in favor of the S3 specific one (`aws-sdk-s3`).

As reported in https://github.com/thoughtbot/paperclip/issues/2484 an initializer like the one in `assets/aws.rb` was necessary for the gem to work correctly, but since paperclip `6.0.0`, it is no longer needed because of the improvement introduced in https://github.com/thoughtbot/paperclip/pull/2481. In this PR the initializer is removed.

As adding the initializer was the only thing that the whole `aws_sdk` recipe was doing, besides adding the old gem, it is also removed in this PR.