### PR TITLE
fix(frontend): use webpacker from rubygems

### DIFF
--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -17,7 +17,7 @@ class Recipes::FrontEnd < Rails::AppBuilder
   def create
     return if [:none, :None].include? get(:front_end).to_sym
 
-    gather_gem 'webpacker', github: 'rails/webpacker'
+    gather_gem 'webpacker'
 
     after(:gem_install) do
       value = get(:front_end)


### PR DESCRIPTION
Arregla error en creación de proyecto nuevo. 

Se usa la última versión estable publicada en RubyGems en vez de confiar que el último commit de github es compatible con nuestro setup.