### PR TITLE
Add data migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ When you choose to deploy to heroku a few extra things are added for the project
     parity between testing and production environments
   - Adds a `.buildpacks` file with the default buildpacks to use. It use the
     following buildpacks:
-  - Adds a `bin/release` file with the release phase script to run specific tasks before the app is deployed completely, for example `rails db:migrate`.
+  - Adds a `bin/release` file with the release phase script to run specific tasks before the app is deployed completely, for example `rails db:migrate:with_data`.
 
 | index | buildpack | description |
 |-------|-----------|-------------|

--- a/lib/potassium/assets/bin/release
+++ b/lib/potassium/assets/bin/release
@@ -4,6 +4,6 @@ set -e
 
 echo 'Release Phase...'
 
-bundle exec rails db:migrate
+bundle exec rails db:migrate:with_data
 
 echo 'Release Phase: OK'

--- a/lib/potassium/recipes/data_migrate.rb
+++ b/lib/potassium/recipes/data_migrate.rb
@@ -1,0 +1,44 @@
+class Recipes::DataMigrate < Rails::AppBuilder
+  def create
+    gather_gem('data_migrate')
+    annotate_task = 'lib/tasks/auto_annotate_models.rake'
+    insert_into_file annotate_task, annotate_config, after: "Annotate.load_tasks\n"
+  end
+
+  def install
+    create
+  end
+
+  def installed?
+    gem_exists?(/data_migrate/)
+  end
+
+  private
+
+  def annotate_config
+    <<-RUBY
+
+  data_migrate_tasks = %w(
+    db:migrate:with_data
+    db:migrate:up:with_data
+    db:migrate:down:with_data
+    db:migrate:redo:with_data
+    db:rollback:with_data
+  )
+
+  data_migrate_tasks.each do |task|
+    Rake::Task[task].enhance do
+      Rake::Task[Rake.application.top_level_tasks.last].enhance do
+        annotation_options_task = if Rake::Task.task_defined?('app:set_annotation_options')
+                                    'app:set_annotation_options'
+                                  else
+                                    'set_annotation_options'
+                                  end
+        Rake::Task[annotation_options_task].invoke
+        Annotate::Migration.update_annotations
+      end
+    end
+  end
+    RUBY
+  end
+end

--- a/lib/potassium/templates/application.rb
+++ b/lib/potassium/templates/application.rb
@@ -45,6 +45,7 @@ run_action(:recipe_loading) do
   create :database_container
   create :database
   create :annotate
+  create :data_migrate
   create :listen
   create :ruby
   create :yarn

--- a/spec/features/data_migrate_spec.rb
+++ b/spec/features/data_migrate_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe 'DataMigrate' do
+  let(:gemfile) { IO.read("#{project_path}/Gemfile") }
+  let(:annotate_task) { IO.read("#{project_path}/lib/tasks/auto_annotate_models.rake") }
+
+  before(:all) do
+    remove_project_directory
+    create_dummy_project
+  end
+
+  it { expect(gemfile).to include("data_migrate") }
+  it { expect(annotate_task).to include("data_migrate_tasks") }
+end

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Heroku" do
     bin_release = IO.read(bin_release_path)
 
     expect(bin_release).to include('set -e')
-    expect(bin_release).to include('bundle exec rails db:migrate')
+    expect(bin_release).to include('bundle exec rails db:migrate:with_data')
     expect(File.stat(bin_release_path)).to be_executable
   end
 end


### PR DESCRIPTION
- Adds new recipe to include gem [`data-migrate`](https://github.com/ilyakatz/data-migrate) in new projects
- Add configuration to `auto_annotate_models` task to generate annotations when using `data-migrate` rake commands (ending in `:with:data`). Configuration was taken from `annotate_models` source code, [here](https://github.com/ctran/annotate_models/blob/develop/lib/tasks/annotate_models_migrate.rake#L7)
- Run `db:migrate:with_data` in release phase

Closes #175 
