### PR TITLE
Vue in compiler mode

### DIFF
--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -33,6 +33,8 @@ class Recipes::FrontEnd < Rails::AppBuilder
         js_pack_tag = "\n    <%= javascript_pack_tag 'application' %>\n"
         layout_file = "app/views/layouts/application.html.erb"
         insert_into_file layout_file, js_pack_tag, after: "<%= csrf_meta_tags %>"
+        insert_into_file layout_file, "<div id=\"vue-app\">\n      <app></app>\n      ", before: "<%= yield %>"
+        insert_into_file layout_file, "\n    </div>", after: "<%= yield %>"
       end
     end
   end

--- a/spec/features/front_end.rb
+++ b/spec/features/front_end.rb
@@ -4,27 +4,30 @@ RSpec.describe "Front end" do
   before(:all) { drop_dummy_database }
   before(:each) { remove_project_directory }
 
+  let(:gemfile) { IO.read("#{project_path}/Gemfile") }
+  let(:node_modules_file) { IO.read("#{project_path}/package.json") }
+  let(:application_js_file) { IO.read("#{project_path}/app/javascript/packs/application.js") }
+  let(:layout_file) { IO.read("#{project_path}/app/views/layouts/application.html.erb") }
+
   it "creates a project wihtout a front end framework" do
     create_dummy_project("front_end" => "None")
-    gemfile = IO.read("#{project_path}/Gemfile")
     expect(gemfile).not_to include('webpacker')
   end
 
   it "creates a project wihtout vue as front end framework" do
     create_dummy_project("front_end" => "angular")
-    gemfile = IO.read("#{project_path}/Gemfile")
-    node_modules_file = IO.read("#{project_path}/package.json")
 
     expect(gemfile).to include('webpacker')
     expect(node_modules_file).to include("\"@angular/core\"")
   end
 
-  it "creates a project wihtout vue as front end framework" do
+  it "creates a project wiht vue in compiler mode as frontend framework" do
     create_dummy_project("front_end" => "vue")
-    gemfile = IO.read("#{project_path}/Gemfile")
-    node_modules_file = IO.read("#{project_path}/package.json")
 
     expect(gemfile).to include('webpacker')
     expect(node_modules_file).to include("\"vue\"")
+    expect(application_js_file).to include('vue/dist/vue.esm')
+    expect(application_js_file).to include("el: '#vue-app'")
+    expect(layout_file).to include('id="vue-app"')
   end
 end


### PR DESCRIPTION
- Se hace que por defecto la aplicación obtenga Vue de la distribución que incluye el compilador. Esto permite usar vue como usualmente lo hacemos en platanus: componentes dentro de vistas/rutas rails, para agregar interactividad sin transformar toda la app en una SPA
- Se adapta el código del `application.js` a partir de lo que se genera con webpacker en [`hello_vue.vue`](https://github.com/rails/webpacker/blob/40987fed31a59dee9501f2832a9ee09603739175/lib/install/examples/vue/hello_vue.js#L35)
- Se incluye en el layout como primer hijo del body un div con id `vue-app` que funciona como el elemento donde se montará vue, permitiendo el uso de componentes en cualquier vista
- Se agrega el componente `app` que se genera como ejemplo también al layout, para que cuando se genere la primera ruta se vea este elemento rendereado
- El html del body del layout al final queda así:
```
<body>
  <div id="vue-app">
    <app></app>
    <%= yield %>
  </div>
</body>
```
![image](https://user-images.githubusercontent.com/12057523/66234419-12820480-e6c4-11e9-8bc7-e4049beea1cc.png)

Closes #230 