### PR TITLE
fix(background_processor): add check for installed heroku recipe

### DIFF
--- a/lib/potassium/recipes/background_processor.rb
+++ b/lib/potassium/recipes/background_processor.rb
@@ -44,7 +44,10 @@ class Recipes::BackgroundProcessor < Rails::AppBuilder
   end
 
   def edit_procfile(cmd)
-    gsub_file("Procfile", /^.*$/m) { |match| "#{match}worker: #{cmd}" } if selected?(:heroku)
+    heroku = load_recipe(:heroku)
+    if selected?(:heroku) || heroku.installed?
+      gsub_file('Procfile', /^.*$/m) { |match| "#{match}worker: #{cmd}" }
+    end
   end
 
   def add_adapters(name)


### PR DESCRIPTION
No estaba agregando la linea en el `Procfile` si `sidekiq` se instala después.