### PR TITLE
fix(sentry): capture 500 api exception

### DIFF
--- a/lib/potassium/assets/api/api_error_concern.rb
+++ b/lib/potassium/assets/api/api_error_concern.rb
@@ -3,6 +3,7 @@ module ApiErrorConcern
 
   included do
     rescue_from "Exception" do |exception|
+      Raven.capture_exception(exception)
       logger.error exception.message
       logger.error exception.backtrace.join("\n")
       respond_api_error(:internal_server_error, message: "server_error",


### PR DESCRIPTION
Actualmente no se capturan en Sentry los errores de API que resultan en 500. Acá se arregla eso.