### PR TITLE
fix(ci): correctly use cache for bundle dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,16 +12,18 @@ jobs:
     - checkout
     - setup_remote_docker
 
+    - run: sudo chown -R circleci /usr/local/bundle
     - restore_cache:
         keys:
-        - v1-dep-{{ .Branch }}-
-        - v1-dep-master-
-    - run: bundle install
+        - potassium-bundle-{{ .Branch }}-
+        - potassium-bundle-master-
+        - potassium-bundle-
+    - run: bundle install --jobs=4 --retry=3
     - run: gem install hound-cli
     - save_cache:
-        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        key: potassium-bundle-{{ .Branch }}-{{ epoch }}
         paths:
-        - vendor/bundle
+        - /usr/local/bundle
     - run:
         command: bundle exec rspec --color --require spec_helper --format=doc --format progress $(circleci tests glob spec/**/*_spec.rb | circleci tests split)
         environment:


### PR DESCRIPTION
This PR fixes the usage of cache in the ci build. Even though cache was saved and restored, paths weren't correctly assigned. 

That's because `bundle install` automatically saves dependencies under the default path defined via environment variables, in this case `/usr/local/bundle`. Changing it to `vendor/bundle` is the recommended way (`bundle install --path vendor/bundle`) but it breaks every test.

I also renamed cache keys/paths and added flags to bundle install to improve efficiency.