### PR TITLE
feat(active-admin): update active admin to 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+Features:
+  - Update ActiveAdmin to 2.6 [#246](https://github.com/platanus/potassium/pull/246)
+
+Fix:
+  - Correctly use cache for bundle dependencies in CircleCi build [#244](https://github.com/platanus/potassium/pull/244)
+
 ## 5.2.3
 
 Features:

--- a/lib/potassium/recipes/admin.rb
+++ b/lib/potassium/recipes/admin.rb
@@ -32,7 +32,7 @@ class Recipes::Admin < Rails::AppBuilder
   private
 
   def add_active_admin
-    gather_gem 'activeadmin', '~> 1.3.0'
+    gather_gem 'activeadmin', '~> 2.6'
     gather_gem 'activeadmin_addons'
     gather_gem 'active_skin'
 


### PR DESCRIPTION
This PR updates the admin recipe to use ActiveAdmin 2.6.0 version. It uses the `~> 2.6` notation so that we don't get _stuck_ in a minor (the last update from 1.1.0 to 1.3.0 was 2 years ago), and get updates until AA 3.0 version is released.  

Compatibility with ActiveAdmin Addons was tested by creating a new app with a sample model with many addons used for inputs and tables.

closes #245