### PR TITLE
Update bundler to 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
         - potassium-bundle-{{ .Branch }}-
         - potassium-bundle-master-
         - potassium-bundle-
+    - run: gem install bundler:2.0.2
     - run: bundle install --jobs=4 --retry=3
     - run: gem install hound-cli
     - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,19 +12,9 @@ jobs:
     - checkout
     - setup_remote_docker
 
-    - run: sudo chown -R circleci /usr/local/bundle
-    - restore_cache:
-        keys:
-        - potassium-bundle-{{ .Branch }}-
-        - potassium-bundle-master-
-        - potassium-bundle-
     - run: gem install bundler:2.0.2
     - run: bundle install --jobs=4 --retry=3
     - run: gem install hound-cli
-    - save_cache:
-        key: potassium-bundle-{{ .Branch }}-{{ epoch }}
-        paths:
-        - /usr/local/bundle
     - run:
         command: bundle exec rspec --color --require spec_helper --format=doc --format progress $(circleci tests glob spec/**/*_spec.rb | circleci tests split)
         environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Features:
   - Update ActiveAdmin to 2.6 [#246](https://github.com/platanus/potassium/pull/246)
+  - Update bundler to 2.0 [#250](https://github.com/platanus/potassium/pull/250)
 
 Fix:
   - Correctly use cache for bundle dependencies in CircleCi build [#244](https://github.com/platanus/potassium/pull/244)

--- a/potassium.gemspec
+++ b/potassium.gemspec
@@ -19,15 +19,15 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "pry", "~> 0.10.3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4.0"
-  spec.add_development_dependency "pry", "~> 0.10.3"
   spec.add_development_dependency "rubocop", Potassium::RUBOCOP_VERSION
   spec.add_development_dependency "rubocop-rspec"
-  spec.add_runtime_dependency "rails", Potassium::RAILS_VERSION
+  spec.add_runtime_dependency "gems", "~> 0.8"
   spec.add_runtime_dependency "gli", "~> 2.12.2"
   spec.add_runtime_dependency "inquirer", "~> 0.2"
-  spec.add_runtime_dependency "gems", "~> 0.8"
-  spec.add_runtime_dependency "semantic", "~> 1.4"
   spec.add_runtime_dependency "levenshtein", "~> 0.2"
+  spec.add_runtime_dependency "rails", Potassium::RAILS_VERSION
+  spec.add_runtime_dependency "semantic", "~> 1.4"
 end

--- a/potassium.gemspec
+++ b/potassium.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "pry", "~> 0.10.3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4.0"


### PR DESCRIPTION
This PR updates bundler to `~> 2.0`. It also sorts alphabetically gemspec dependencies for consistency.

Some unknown bugs in the CI build were happening related to cache issues. For now cache restore will be disabled until I figure out the best way to deal with it.

closes #249 