### PR TITLE
Update rails to 6.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Features:
   - Update ActiveAdmin to 2.6 [#246](https://github.com/platanus/potassium/pull/246)
   - Update bundler to 2.0 [#250](https://github.com/platanus/potassium/pull/250)
+  - Update Rails to 6.0.2 [#251](https://github.com/platanus/potassium/pull/251)
 
 Fix:
   - Correctly use cache for bundle dependencies in CircleCi build [#244](https://github.com/platanus/potassium/pull/244)

--- a/lib/potassium/recipes/admin.rb
+++ b/lib/potassium/recipes/admin.rb
@@ -34,7 +34,7 @@ class Recipes::Admin < Rails::AppBuilder
   def add_active_admin
     gather_gem 'activeadmin', '~> 2.6'
     gather_gem 'activeadmin_addons'
-    gather_gem 'active_skin'
+    gather_gem 'active_skin', github: 'SoftwareBrothers/active_skin'
 
     after(:gem_install, wrap_in_action: :admin_install) do
       generate "active_admin:install"

--- a/lib/potassium/recipes/draper.rb
+++ b/lib/potassium/recipes/draper.rb
@@ -21,7 +21,7 @@ class Recipes::Draper < Rails::AppBuilder
   end
 
   def add_draper
-    gather_gem 'draper', '3.0.1'
+    gather_gem 'draper', '~> 3.1'
     add_readme_section :internal_dependencies, :draper
     create_file 'app/decorators/.keep'
   end

--- a/lib/potassium/version.rb
+++ b/lib/potassium/version.rb
@@ -1,7 +1,7 @@
 module Potassium
   VERSION = "5.2.3"
   RUBY_VERSION = "2.5.5"
-  RAILS_VERSION = "~> 5.2.1"
+  RAILS_VERSION = "~> 6.0.2"
   RUBOCOP_VERSION = "~> 0.65.0"
   POSTGRES_VERSION = "11.3"
   MYSQL_VERSION = "5.7"

--- a/spec/features/power_types_spec.rb
+++ b/spec/features/power_types_spec.rb
@@ -17,21 +17,10 @@ RSpec.describe "PowerTypes" do
     expect(readme).to include("Power-Types")
   end
 
-  it "adds commands directory" do
-    commands_directory = "#{project_path}/app/commands"
-    expect(File.directory?(commands_directory)).to eq(true)
-  end
-
-  it "adds services directory" do
-    services_directory = "#{project_path}/app/services"
-    expect(File.directory?(services_directory)).to eq(true)
-  end
-  it "adds utils directory" do
-    utils_directory = "#{project_path}/app/utils"
-    expect(File.directory?(utils_directory)).to eq(true)
-  end
-  it "adds values directory" do
-    values_directory = "#{project_path}/app/values"
-    expect(File.directory?(values_directory)).to eq(true)
+  it "adds every power type directory" do
+    [:commands, :services, :observers, :utils, :values].each do |type|
+      commands_directory = "#{project_path}/app/#{type}"
+      expect(File.directory?(commands_directory)).to eq(true)
+    end
   end
 end

--- a/spec/support/potassium_test_helpers.rb
+++ b/spec/support/potassium_test_helpers.rb
@@ -19,6 +19,7 @@ module PotassiumTestHelpers
     Dir.chdir(tmp_path) do
       Bundler.with_clean_env do
         add_fakes_to_path
+        add_project_bin_to_path
         full_arguments = hash_to_arguments(create_arguments(true).merge(arguments))
         run_command("#{potassium_bin} create #{APP_NAME} #{full_arguments}")
         on_project { run_command("hound rules update ruby --local") }
@@ -32,8 +33,12 @@ module PotassiumTestHelpers
     on_project { run_command("bundle exec rails db:drop") }
   end
 
+  def add_project_bin_to_path
+    add_to_path project_bin, true
+  end
+
   def add_fakes_to_path
-    ENV["PATH"] = "#{support_bin}:#{ENV['PATH']}"
+    add_to_path support_bin
   end
 
   def project_path
@@ -64,6 +69,14 @@ module PotassiumTestHelpers
         "--#{key}=#{value}"
       end
     end.join(" ")
+  end
+
+  def add_to_path(new_path, append = false)
+    ENV['PATH'] = append ? "#{ENV['PATH']}:#{new_path}" : "#{new_path}:#{ENV['PATH']}"
+  end
+
+  def project_bin
+    File.join(project_path, 'bin')
   end
 
   def potassium_bin

--- a/spec/support/potassium_test_helpers.rb
+++ b/spec/support/potassium_test_helpers.rb
@@ -28,6 +28,7 @@ module PotassiumTestHelpers
 
   def drop_dummy_database
     return unless File.exist?(project_path)
+
     on_project { run_command("bundle exec rails db:drop") }
   end
 
@@ -53,14 +54,6 @@ module PotassiumTestHelpers
 
   private
 
-  def tmp_path
-    @tmp_path ||= Pathname.new("#{root_path}/tmp")
-  end
-
-  def potassium_bin
-    File.join(root_path, "bin", "potassium")
-  end
-
   def hash_to_arguments(hash)
     hash.map do |key, value|
       if value == true
@@ -73,8 +66,16 @@ module PotassiumTestHelpers
     end.join(" ")
   end
 
+  def potassium_bin
+    File.join(root_path, "bin", "potassium")
+  end
+
   def support_bin
     File.join(root_path, "spec", "fakes", "bin")
+  end
+
+  def tmp_path
+    @tmp_path ||= Pathname.new("#{root_path}/tmp")
   end
 
   def root_path


### PR DESCRIPTION
This PR updates rails to 6.0.2.

In order to do that, `draper` needed to be updated to 3.1, alongside `active_skin`, which has many changes since the last published version (0.0.12) and they haven't made a release since 2015, so I referenced the github repo.

For rails 6.0.0 the behavior of rails generator's `generate` command changed slightly. Until 5.X every `generate sth` call was translated to a `bin/rails generate sth` command, but now it translates to `rails generate sth` ([rails/rails#34420](https://github.com/rails/rails/pull/34420/files#diff-5036eb99239f9418c0458f2a2ec4f496L226-L227)). As this change broke the test build in the CI, a new step is included in the spec helper to add `dummy_app/bin` to the `PATH` env var.

I slipped in a minor change in the power types specs, as they were using 1 example per directory created (commands, observers, etc.) which meant that a new project was set up every time. I merged those into 1 example with 5 expectations instead.

closes #247, closes #212
