### PR TITLE
feat(ci): use cache and vendor/bundle as path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,16 +7,30 @@ jobs:
 
     docker:
     - image: circleci/ruby:2.5.5-node
+      environment:
+        GEM_HOME: /home/circleci/app/vendor/bundle
+        BUNDLE_JOBS: 4
+        BUNDLE_RETRY: 3
+        BUNDLE_PATH: /home/circleci/app/vendor/bundle
 
     steps:
     - checkout
     - setup_remote_docker
 
+    - restore_cache:
+        keys:
+          - potassium-bundle-{{ .Branch }}-
+          - potassium-bundle-master-
+          - potassium-bundle-
     - run: gem install bundler:2.0.2
-    - run: bundle install --jobs=4 --retry=3
+    - run: bundle install
     - run: gem install hound-cli
     - run:
         command: bundle exec rspec --color --require spec_helper --format=doc --format progress $(circleci tests glob spec/**/*_spec.rb | circleci tests split)
         environment:
           RAILS_ENV: test
           RACK_ENV: test
+    - save_cache:
+        key: potassium-bundle-{{ .Branch }}-{{ epoch }}
+        paths:
+          - vendor/bundle


### PR DESCRIPTION
This PR reinstates cache for the ci build 🎉!

For caching the recommended way is to use the `vendor/bundle` path, but that brought some problems for this specific case, as some gems are used not in a `bundle exec` way, like when we use `potassium create` to create a project inside the specs. That meant that using that path would cause a not found error when requiring dependencies.

That's why I changed the env var `GEM_HOME` so that gems would be available outside of the scope of the root project. By doing that, as a nice side effect, gems for the spec created projects are also restored from cache.

Another major change is that cache is saved after specs are finished. This allows new project gems to be cached and not only potassium dependencies.

closes #256