### PR TITLE
Improve specs performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ Features:
   - Update ActiveAdmin to 2.6 [#246](https://github.com/platanus/potassium/pull/246)
   - Update bundler to 2.0 [#250](https://github.com/platanus/potassium/pull/250)
   - Update Rails to 6.0.2 [#251](https://github.com/platanus/potassium/pull/251)
+  - Improve specs performance [#259](https://github.com/platanus/potassium/pull/259)
 
 Fix:
-  - Correctly use cache for bundle dependencies in CircleCi build [#244](https://github.com/platanus/potassium/pull/244)
+  - Correctly use cache for bundle dependencies in CircleCI build [#244](https://github.com/platanus/potassium/pull/244) and [#258](https://github.com/platanus/potassium/pull/258)
 
 ## 5.2.3
 

--- a/lib/potassium/cli/commands/create.rb
+++ b/lib/potassium/cli/commands/create.rb
@@ -25,6 +25,7 @@ module Potassium::CLI
         template = template_finder.default_template
         template.cli_options = options
         template.source_paths << Rails::Generators::AppGenerator.source_root
+        ARGV.push('--skip-webpack-install', '--skip-bundle')
         template.start
       end
 

--- a/lib/potassium/cli_options.rb
+++ b/lib/potassium/cli_options.rb
@@ -16,7 +16,7 @@ module Potassium::CliOptions # rubocop:disable Metrics/ModuleLength
       type: :flag,
       name: [:email_service, :email],
       desc: "Decides which email adapter to use. Available: aws_ses, sendgrid, none",
-      default_test_value: "aws_ses"
+      default_test_value: "None"
     },
     {
       type: :switch,
@@ -71,7 +71,7 @@ module Potassium::CliOptions # rubocop:disable Metrics/ModuleLength
       name: "storage",
       desc: "Decides which file storage to use. Available: active_storage, paperclip, none",
       default_value: "none",
-      default_test_value: "active_storage"
+      default_test_value: "None"
     },
     {
       type: :switch,
@@ -85,7 +85,7 @@ module Potassium::CliOptions # rubocop:disable Metrics/ModuleLength
       type: :flag,
       name: "background_processor",
       desc: "Decides which background processor to use. Available: sidekiq, delayed_job, none",
-      default_test_value: "sidekiq"
+      default_test_value: "None"
     },
     {
       type: :switch,

--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -17,8 +17,6 @@ class Recipes::FrontEnd < Rails::AppBuilder
   def create
     return if [:none, :None].include? get(:front_end).to_sym
 
-    gather_gem 'webpacker'
-
     recipe = self
     after(:gem_install) do
       value = get(:front_end)


### PR DESCRIPTION
This PR improves test speeds by changing default test values for some recipes to none. This prevents unnecesary steps like `rails generate active_storage:install` in every spec. 

This PR also adds 2 flags to the base template (which are passed to `rails new`): `--skip-bundle-install` and `--skip-webpack-install`. This addresses #252 as the frontend recipe is now the only one that executes `rails g webpack:install`. This also avoids multiple calls of `bundle install`, as it is called from one recipe.

**\* P.S.:** Webpacker gem is included by default by rails even with the `--skip-webpack-install` (and it is a expected behaviour, as the flag is only intended to skip the `:install` steps).

closes #252, closes #257 