### PR TITLE
Fix annotate models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Features:
 
 Fix:
   - Correctly use cache for bundle dependencies in CircleCI build [#244](https://github.com/platanus/potassium/pull/244) and [#258](https://github.com/platanus/potassium/pull/258)
+  - Fix model auto annotate [#260](https://github.com/platanus/potassium/pull/260)
 
 ## 5.2.3
 

--- a/lib/potassium/assets/lib/tasks/auto_annotate_models.rake
+++ b/lib/potassium/assets/lib/tasks/auto_annotate_models.rake
@@ -36,7 +36,8 @@ if Rails.env.development?
       'force' => 'false',
       'trace' => 'false',
       'wrapper_open' => nil,
-      'wrapper_close' => nil
+      'wrapper_close' => nil,
+      'models' => true
     )
   end
 

--- a/lib/potassium/recipes/annotate.rb
+++ b/lib/potassium/recipes/annotate.rb
@@ -1,7 +1,7 @@
 class Recipes::Annotate < Rails::AppBuilder
   def create
     gather_gems(:development) do
-      gather_gem('annotate')
+      gather_gem('annotate', '~> 3.0')
     end
 
     template '../assets/lib/tasks/auto_annotate_models.rake',


### PR DESCRIPTION
Fixes #255:
- Problem occurred because of a breaking change in annotate v3
- Fixes gem's version to `~> 3.0` (latest release is 3.0.3)