### PR TITLE
feat(ci): split specs by timings for parallel run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,11 @@ jobs:
     - run: bundle install
     - run: gem install hound-cli
     - run:
-        command: bundle exec rspec --color --require spec_helper --format=doc --format progress $(circleci tests glob spec/**/*_spec.rb | circleci tests split)
+        command: |
+          bundle exec rspec --color --require spec_helper --profile 10 \
+                            --format progress --format documentation \
+                            --format RspecJunitFormatter --out test_results/rspec.xml \
+                            $(circleci tests glob spec/**/*_spec.rb | circleci tests split --split-by=timings)
         environment:
           RAILS_ENV: test
           RACK_ENV: test
@@ -34,3 +38,5 @@ jobs:
         key: potassium-bundle-{{ .Branch }}-{{ epoch }}
         paths:
           - vendor/bundle
+    - store_test_results:
+        path: test_results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
   - Update Rails to 6.0.2 [#251](https://github.com/platanus/potassium/pull/251)
   - Improve specs performance [#259](https://github.com/platanus/potassium/pull/259)
   - Dasherize app name in docker compose related files [#261](https://github.com/platanus/potassium/pull/261)
+  - Split specs by timings in CircleCI [#263](https://github.com/platanus/potassium/pull/263)
 
 Fix:
   - Correctly use cache for bundle dependencies in CircleCI build [#244](https://github.com/platanus/potassium/pull/244) and [#258](https://github.com/platanus/potassium/pull/258)

--- a/potassium.gemspec
+++ b/potassium.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.10.3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4.0"
+  spec.add_development_dependency "rspec_junit_formatter"
   spec.add_development_dependency "rubocop", Potassium::RUBOCOP_VERSION
   spec.add_development_dependency "rubocop-rspec"
   spec.add_runtime_dependency "gems", "~> 0.8"


### PR DESCRIPTION
This PR improves CircleCI build time by considering timings for spec splitting. We gain more than one minute in total.

Further improvement is possible but I think that it should be done in a spec-by-spec basis, as some specs like the [ci recipe one](https://github.com/platanus/potassium/blob/master/spec/features/ci_spec.rb) are extremely slow.