### PR TITLE
feat(rack-cors): update rack cors to ~> 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Features:
   - Split specs by timings in CircleCI [#263](https://github.com/platanus/potassium/pull/263)
   - Update ruby to 2.7.0 [#264](https://github.com/platanus/potassium/pull/264)
   - Add tailwindcss [#266](https://github.com/platanus/potassium/pull/266)
+  - Update rack-cors to 1.1 [#269](https://github.com/platanus/potassium/pull/269)
 
 Fix:
   - Correctly use cache for bundle dependencies in CircleCI build [#244](https://github.com/platanus/potassium/pull/244) and [#258](https://github.com/platanus/potassium/pull/258)

--- a/lib/potassium/recipes/rack_cors.rb
+++ b/lib/potassium/recipes/rack_cors.rb
@@ -4,23 +4,25 @@ class Recipes::RackCors < Rails::AppBuilder
   end
 
   def create
-    gather_gem('rack-cors', '~> 0.4.0')
+    gather_gem('rack-cors', '~> 1.1')
+    recipe = self
     after(:gem_install) do
-      rack_cors_config =
-        <<~RUBY
-          config.middleware.insert_before 0, Rack::Cors do
-            allow do
-              origins '*'
-              resource '*',
-                headers: :any,
-                expose: ['X-Page', 'X-PageTotal'],
-                methods: [:get, :post, :delete, :put, :options]
-            end
-          end
-
-        RUBY
-
-      application rack_cors_config
+      application recipe.rack_cors_config
     end
+  end
+
+  def rack_cors_config
+    <<~RUBY
+      config.middleware.insert_before 0, Rack::Cors do
+        allow do
+          origins '*'
+          resource '*',
+            headers: :any,
+            expose: ['X-Page', 'X-PageTotal'],
+            methods: [:get, :post, :delete, :put, :options]
+        end
+      end
+
+    RUBY
   end
 end


### PR DESCRIPTION
This PR updates rack-cors in order to remove vulnerability warnings from freshly bundled potassium projects. After this PR we should address #202. 

closes #265 
