### PR TITLE
feat(cors): use safer api/public-only CORS configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Features:
   - Update ruby to 2.7.0 [#264](https://github.com/platanus/potassium/pull/264)
   - Add tailwindcss [#266](https://github.com/platanus/potassium/pull/266)
   - Update rack-cors to 1.1 [#269](https://github.com/platanus/potassium/pull/269)
+  - Use safer CORS configuration exposing only API and public resources [#271](https://github.com/platanus/potassium/pull/271)
 
 Fix:
   - Correctly use cache for bundle dependencies in CircleCI build [#244](https://github.com/platanus/potassium/pull/244) and [#258](https://github.com/platanus/potassium/pull/258)

--- a/lib/potassium/recipes/rack_cors.rb
+++ b/lib/potassium/recipes/rack_cors.rb
@@ -16,10 +16,11 @@ class Recipes::RackCors < Rails::AppBuilder
       config.middleware.insert_before 0, Rack::Cors do
         allow do
           origins '*'
-          resource '*',
+          resource '/public/*', headers: :any, methods: :get
+          resource '/api/*',
             headers: :any,
             expose: ['X-Page', 'X-PageTotal'],
-            methods: [:get, :post, :delete, :put, :options]
+            methods: [:get, :post, :patch, :put, :delete, :options]
         end
       end
 


### PR DESCRIPTION
This PR modifies the default configuration bundled by the rack-cors recipe. As of today we were allowing requests from any origin to any resource, which is a very unsafe configuration. The new config only allows get requests to the urls under `public` and index/show/create/update/delete requests for urls under `api`.

closes #202