### PR TITLE
fix(Makefile): change stop and down services names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Fix:
   - Fix model auto annotate [#260](https://github.com/platanus/potassium/pull/260)
   - Fix sidekiq repeated installation on potassium create if selecting mailer [#262](https://github.com/platanus/potassium/pull/262)
   - Include ApiErrorConcern in all environments [#270](https://github.com/platanus/potassium/pull/270)
+  - Change stop and down services names in Makefile [#273](https://github.com/platanus/potassium/pull/273)
 
 ## 5.2.3
 

--- a/lib/potassium/assets/Makefile.erb
+++ b/lib/potassium/assets/Makefile.erb
@@ -32,10 +32,10 @@ services-ps:
 services-up:
 	docker-compose $(DOCKER_COMPOSE_ARGS) up -d
 
-services-stop:
+services-down:
 	docker-compose $(DOCKER_COMPOSE_ARGS) stop
 
-services-down:
+services-destroy:
 	docker-compose $(DOCKER_COMPOSE_ARGS) down --volumes
 
 services-logs:


### PR DESCRIPTION
For what I can see in #197, and particularly in [this commit](https://github.com/platanus/potassium/pull/197/commits/8749a9eaa54229d091238137178ad799e05754b7) the original idea was for the names to be what these PR indicates.

The idea behind this is that `services-down` should just stop the containers/volumes (so that it's the contrary to up), but doing `down --volumes` actually destroys volume data