### PR TITLE
 fix(vue-admin): fix case when binding case uses shorthand syntax

### DIFF
--- a/lib/potassium/recipes/vue_admin.rb
+++ b/lib/potassium/recipes/vue_admin.rb
@@ -92,7 +92,7 @@ class Recipes::VueAdmin < Rails::AppBuilder
             dasherized_key = key.to_s.dasherize
             if value.is_a?(String)
               vue_attributes[dasherized_key] = value
-            elsif dasherized_key.index(':').zero?
+            elsif !dasherized_key.index(':').nil? && dasherized_key.index(':').zero?
               vue_attributes[dasherized_key] = value.to_json
             else
               vue_attributes[":" + dasherized_key] = value.to_json


### PR DESCRIPTION
- Found a case when using shorthand syntax for Vue binding keys, the translation throws an exception.
- For example: `v-bind:key` can be written as `:key` and this was causing an error.