### PR TITLE
Remove makefile commands

### DIFF
--- a/lib/potassium/assets/Makefile.erb
+++ b/lib/potassium/assets/Makefile.erb
@@ -1,7 +1,6 @@
 PROJECT ?= <%= get(:dasherized_app_name) %>
-DOCKER_COMPOSE_FILE ?= docker-compose.yml
 
-DOCKER_COMPOSE_ARGS ?= -p $(PROJECT) -f $(DOCKER_COMPOSE_FILE)
+DOCKER_COMPOSE_ARGS ?= -p $(PROJECT)
 
 SHELL := /bin/bash
 

--- a/lib/potassium/assets/Makefile.erb
+++ b/lib/potassium/assets/Makefile.erb
@@ -10,35 +10,12 @@ BOLD ?= $(shell tput bold)
 NORMAL ?= $(shell tput sgr0)
 
 help:
-	@echo Install dependencies:
-	@echo "  ${BOLD}make setup${NORMAL}"
+	@echo "Generate a backup in the environment (staging|production) database:"
+	@echo "  ${BOLD}make backup-<environment>${NORMAL}"
 	@echo ""
-	@echo Runing the services like mysql:
-	@echo "  ${BOLD}make services-up${NORMAL}"
+	@echo "Copy latest database backup from the environment (staging|production) to local database:"
+	@echo "  ${BOLD}make restore-from-<environment>${NORMAL}"
 	@echo ""
-	@echo "Reset the environment (rm mysql db):"
-	@echo "  ${BOLD}make services-down${NORMAL}"
-	@echo ""
-
-setup:
-	bin/setup
-
-services: services-up
-
-services-ps:
-	docker-compose $(DOCKER_COMPOSE_ARGS) ps
-
-services-up:
-	docker-compose $(DOCKER_COMPOSE_ARGS) up -d
-
-services-down:
-	docker-compose $(DOCKER_COMPOSE_ARGS) stop
-
-services-destroy:
-	docker-compose $(DOCKER_COMPOSE_ARGS) down --volumes
-
-services-logs:
-	docker-compose $(DOCKER_COMPOSE_ARGS) logs -f
 
 services-port:
 	@set -o pipefail; \

--- a/lib/potassium/assets/Makefile.erb
+++ b/lib/potassium/assets/Makefile.erb
@@ -1,7 +1,5 @@
 PROJECT ?= <%= get(:dasherized_app_name) %>
 
-DOCKER_COMPOSE_ARGS ?= -p $(PROJECT)
-
 SHELL := /bin/bash
 
 run: help
@@ -19,7 +17,7 @@ help:
 
 services-port:
 	@set -o pipefail; \
-	docker-compose $(DOCKER_COMPOSE_ARGS) port ${SERVICE} ${PORT} 2> /dev/null | cut -d':' -f2 || echo ${PORT}
+	docker-compose port ${SERVICE} ${PORT} 2> /dev/null | cut -d':' -f2 || echo ${PORT}
 
 backup-staging: ROLE=staging
 backup-production: ROLE=production

--- a/lib/potassium/assets/bin/setup.erb
+++ b/lib/potassium/assets/bin/setup.erb
@@ -14,7 +14,7 @@ bundle check || bundle install
 bin/yarn install
 
 # Set up required services
-docker-compose -p <%= get(:dasherized_app_name) %> up -d
+docker-compose up -d
 
 # Set up database
 bin/rails db:setup

--- a/lib/potassium/assets/bin/setup.erb
+++ b/lib/potassium/assets/bin/setup.erb
@@ -14,7 +14,7 @@ bundle check || bundle install
 bin/yarn install
 
 # Set up required services
-make services-up
+docker-compose -p <%= get(:dasherized_app_name) %> up -d
 
 # Set up database
 bin/rails db:setup

--- a/lib/potassium/recipes/database_container.rb
+++ b/lib/potassium/recipes/database_container.rb
@@ -38,7 +38,7 @@ class Recipes::DatabaseContainer < Rails::AppBuilder
     compose.add_volume("#{db_type}_data")
     template '../assets/Makefile.erb', 'Makefile'
 
-    run 'make services-up'
+    run "docker-compose -p #{get(:dasherized_app_name)} up -d"
 
     set_env(db_type, CONTAINER_VARS[db_type][:port], CONTAINER_VARS[db_type][:user])
     set_dot_env(db_type, CONTAINER_VARS[db_type][:port], CONTAINER_VARS[db_type][:user])
@@ -54,7 +54,7 @@ class Recipes::DatabaseContainer < Rails::AppBuilder
     setup_text = # setup file is templated on project creation, manual install is needed
       <<~TEXT
         # Set up required services
-        make services-up
+        docker-compose -p #{get(:dasherized_app_name)} up -d
 
       TEXT
 

--- a/lib/potassium/recipes/database_container.rb
+++ b/lib/potassium/recipes/database_container.rb
@@ -38,7 +38,7 @@ class Recipes::DatabaseContainer < Rails::AppBuilder
     compose.add_volume("#{db_type}_data")
     template '../assets/Makefile.erb', 'Makefile'
 
-    run "docker-compose -p #{get(:dasherized_app_name)} up -d"
+    run "docker-compose up -d"
 
     set_env(db_type, CONTAINER_VARS[db_type][:port], CONTAINER_VARS[db_type][:user])
     set_dot_env(db_type, CONTAINER_VARS[db_type][:port], CONTAINER_VARS[db_type][:user])
@@ -54,7 +54,7 @@ class Recipes::DatabaseContainer < Rails::AppBuilder
     setup_text = # setup file is templated on project creation, manual install is needed
       <<~TEXT
         # Set up required services
-        docker-compose -p #{get(:dasherized_app_name)} up -d
+        docker-compose up -d
 
       TEXT
 

--- a/spec/features/database_container_spec.rb
+++ b/spec/features/database_container_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe "DatabaseContainer" do
         compose_file = IO.read("#{project_path}/docker-compose.yml")
         compose_content = YAML.safe_load(compose_file, symbolize_names: true)
         setup_file = IO.read("#{project_path}/bin/setup")
-        app_name = PotassiumTestHelpers::APP_NAME.dasherize
 
         service_name = compose_content[:services].keys.first
         db_port = compose_content[:services][service_name][:ports].first
@@ -29,7 +28,7 @@ RSpec.describe "DatabaseContainer" do
           .to include("DB_PORT=$(make services-port SERVICE=#{service_name} PORT=#{db_port})")
         expect(env_file).to include("DB_HOST=127.0.0.1")
         expect(File.exist?("#{project_path}/Makefile")).to be true
-        expect(setup_file).to include("docker-compose -p #{app_name} up -d")
+        expect(setup_file).to include("docker-compose up -d")
       end
     end
   end

--- a/spec/features/database_container_spec.rb
+++ b/spec/features/database_container_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "DatabaseContainer" do
         compose_file = IO.read("#{project_path}/docker-compose.yml")
         compose_content = YAML.safe_load(compose_file, symbolize_names: true)
         setup_file = IO.read("#{project_path}/bin/setup")
+        app_name = PotassiumTestHelpers::APP_NAME.dasherize
 
         service_name = compose_content[:services].keys.first
         db_port = compose_content[:services][service_name][:ports].first
@@ -28,7 +29,7 @@ RSpec.describe "DatabaseContainer" do
           .to include("DB_PORT=$(make services-port SERVICE=#{service_name} PORT=#{db_port})")
         expect(env_file).to include("DB_HOST=127.0.0.1")
         expect(File.exist?("#{project_path}/Makefile")).to be true
-        expect(setup_file).to include("make services-up")
+        expect(setup_file).to include("docker-compose -p #{app_name} up -d")
       end
     end
   end


### PR DESCRIPTION
- Removes simple `docker-compose` commands and `bin/setup` from Makefile
- Changes help to only include instructions for backup/restore