### PR TITLE
chore(): update tailwind imports syntax

### DIFF
--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -142,9 +142,9 @@ class Recipes::FrontEnd < Rails::AppBuilder
 
   def tailwind_client_css
     <<~CSS
-      @import 'tailwindcss/base';
-      @import 'tailwindcss/components';
-      @import 'tailwindcss/utilities';
+      @tailwind base;
+      @tailwind components;
+      @tailwind utilities;
     CSS
   end
 


### PR DESCRIPTION
Replaces tailwind imports with postcss directives (to better follow the official guide.)