### PR TITLE
Change circleCI folder name to .circleCi

### DIFF
--- a/lib/potassium/recipes/ci.rb
+++ b/lib/potassium/recipes/ci.rb
@@ -1,7 +1,7 @@
 class Recipes::Ci < Rails::AppBuilder
   def create
     copy_file '../assets/Dockerfile.ci', 'Dockerfile.ci'
-    template '../assets/.circleci/config.yml.erb', 'circleci/config.yml'
+    template '../assets/.circleci/config.yml.erb', '.circleci/config.yml'
 
     template '../assets/bin/cibuild.erb', 'bin/cibuild'
     run "chmod a+x bin/cibuild"


### PR DESCRIPTION
Rename `circleci` folder to `.circleci` for CircleCI integration to work right out of the box.