### PR TITLE
fix(ci): Change circleci folder name to .circleci

### DIFF
--- a/lib/potassium/recipes/ci.rb
+++ b/lib/potassium/recipes/ci.rb
@@ -1,7 +1,7 @@
 class Recipes::Ci < Rails::AppBuilder
   def create
     copy_file '../assets/Dockerfile.ci', 'Dockerfile.ci'
-    template '../assets/.circleci/config.yml.erb', 'circleci/config.yml'
+    template '../assets/.circleci/config.yml.erb', '.circleci/config.yml'
 
     template '../assets/bin/cibuild.erb', 'bin/cibuild'
     run "chmod a+x bin/cibuild"


### PR DESCRIPTION
Change `circleci` folder name to `.circleci` so that CircleCI integration works right out of the box.