### PR TITLE
Reviewdog

### DIFF
--- a/lib/potassium/assets/.circleci/config.yml.erb
+++ b/lib/potassium/assets/.circleci/config.yml.erb
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  test:
     working_directory: ~/app
 
     docker:
@@ -21,3 +21,82 @@ jobs:
     <% if selected?(:front_end, :vue) %>
     - run: bin/cibuild js_tests
     <% end %>
+
+  lint:
+    docker:
+      - image: circleci/ruby:2.7-node
+        environment:
+          BUNDLE_JOBS: 4
+          BUNDLE_RETRY: 3
+          BUNDLE_PATH: vendor/bundle
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+          - bundle-dependencies-{{ checksum "Gemfile.lock" }}
+          - bundle-dependencies-
+
+      - restore_cache:
+          keys:
+          - yarn-dependencies-{{ checksum "yarn.lock" }}
+          - yarn-dependencies-
+
+      - run:
+          name: Install bundle dependencies
+          command: |
+            BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")
+            gem install bundler:$BUNDLER_VERSION
+            bundle _$(echo $BUNDLER_VERSION)_ install
+
+      - save_cache:
+          key: bundle-dependencies-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+
+      - run:
+          name: Install yarn dependencies
+          command: yarn install --frozen-lockfile
+
+      - save_cache:
+          key: yarn-dependencies-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+
+      - run:
+          name: Install reviewdog
+          command: |
+            curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b ./bin
+
+      - run:
+          name: Get files to lint
+          command: git diff origin/master --name-only --diff-filter=d > tmp/files_to_lint
+
+      - run:
+          name: Run rubocop
+          shell: /bin/bash
+          command: |
+            cat tmp/files_to_lint | grep -E '.+\.(rb)$' | xargs bundle exec rubocop --force-exclusion \
+            | ./bin/reviewdog -reporter=github-pr-review -f=rubocop
+
+      - run:
+          name: Run eslint
+          shell: /bin/bash
+          command: |
+            cat tmp/files_to_lint | grep -E '.+\.(js|jsx|vue)$' | xargs yarn run eslint \
+            | ./bin/reviewdog -reporter=github-pr-review -f=eslint
+
+      - run:
+          name: Run stylelint
+          shell: /bin/bash
+          command: |
+            cat tmp/files_to_lint | grep -E '.+\.(scss|css|less)$' | xargs yarn run stylelint \
+            | ./bin/reviewdog -reporter=github-pr-review -f=stylelint
+
+workflows:
+  version: 2
+  test_and_lint:
+    jobs:
+      - test
+      - lint:
+          context: org-global

--- a/lib/potassium/assets/.eslintrc.json
+++ b/lib/potassium/assets/.eslintrc.json
@@ -1,0 +1,343 @@
+{
+  "env": {
+    "es6": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2018,
+    "sourceType": "module"
+  },
+  "plugins": ["import"],
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".json"]
+      }
+    }
+  },
+  "extends": [
+    "plugin:vue/strongly-recommended"
+  ],
+  "rules": {
+    "accessor-pairs": 0,
+    "array-callback-return": 2,
+    "block-scoped-var": 2,
+    "complexity": [1, {
+      "max": 20
+    }],
+    "consistent-return": 2,
+    "curly": [2, "multi-line"],
+    "default-case": [2, {
+      "commentPattern": "^no default$"
+    }],
+    "dot-notation": [1, {
+      "allowKeywords": true
+    }],
+    "dot-location": [2, "property"],
+    "eqeqeq": [2],
+    "guard-for-in": 2,
+    "no-alert": 1,
+    "no-case-declarations": 2,
+    "no-div-regex": 0,
+    "no-else-return": 2,
+    "no-empty-function": [2, {
+      "allow": ["arrowFunctions", "functions", "methods"]
+    }],
+    "no-empty-pattern": 2,
+    "no-eval": 2,
+    "no-extend-native": 2,
+    "no-extra-bind": 2,
+    "no-fallthrough": 2,
+    "no-floating-decimal": 2,
+    "no-implicit-coercion": 0,
+    "no-implicit-globals": 2,
+    "no-implied-eval": 2,
+    "no-invalid-this": 0,
+    "no-iterator": 2,
+    "no-extra-label": 2,
+    "no-labels": [2, {
+      "allowLoop": false,
+      "allowSwitch": false
+    }],
+    "no-lone-blocks": 2,
+    "no-loop-func": 2,
+    "no-magic-numbers": [2, {
+      "ignore": [0, 1, -1]
+    }],
+    "no-multi-spaces": 2,
+    "no-multi-str": 2,
+    "no-native-reassign": 2,
+    "no-new": 2,
+    "no-new-func": 2,
+    "no-new-wrappers": 2,
+    "no-octal": 2,
+    "no-octal-escape": 2,
+    "no-param-reassign": [2, {
+      "props": false
+    }],
+    "no-proto": 2,
+    "no-redeclare": 2,
+    "no-return-assign": 2,
+    "no-script-url": 2,
+    "no-self-assign": 2,
+    "no-self-compare": 2,
+    "no-sequences": 2,
+    "no-throw-literal": 2,
+    "no-unmodified-loop-condition": 0,
+    "no-unused-expressions": 2,
+    "no-unused-labels": 2,
+    "no-useless-call": 0,
+    "no-useless-concat": 2,
+    "no-useless-escape": 2,
+    "no-void": 0,
+    "no-warning-comments": [1, {
+      "terms": ["todo", "fixme", "xxx"],
+      "location": "start"
+    }],
+    "no-with": 2,
+    "radix": 2,
+    "vars-on-top": 2,
+    "wrap-iife": [2, "any"],
+    "yoda": 2,
+    "comma-dangle": [2, "always-multiline"],
+    "no-cond-assign": [2, "always"],
+    "no-console": 0,
+    "no-debugger": 0,
+    "no-constant-condition": 2,
+    "no-control-regex": 2,
+    "no-dupe-args": 2,
+    "no-dupe-keys": 2,
+    "no-duplicate-case": 2,
+    "no-empty": 2,
+    "no-empty-character-class": 2,
+    "no-ex-assign": 2,
+    "no-extra-boolean-cast": 0,
+    "no-extra-parens": [0, "all", {
+      "conditionalAssign": true,
+      "nestedBinaryExpressions": false,
+      "returnAssign": false
+    }],
+    "no-extra-semi": 2,
+    "no-func-assign": 2,
+    "no-inner-declarations": 2,
+    "no-invalid-regexp": 2,
+    "no-irregular-whitespace": 2,
+    "no-negated-in-lhs": 2,
+    "no-obj-calls": 2,
+    "no-regex-spaces": 2,
+    "no-sparse-arrays": 2,
+    "no-unexpected-multiline": 0,
+    "no-unreachable": 2,
+    "no-unsafe-finally": 2,
+    "use-isnan": 2,
+    "valid-jsdoc": 0,
+    "valid-typeof": 2,
+    "arrow-body-style": [2, "as-needed"],
+    "arrow-parens": 0,
+    "arrow-spacing": [2, {
+      "before": true,
+      "after": true
+    }],
+    "constructor-super": 0,
+    "generator-star-spacing": [2, {
+      "before": true,
+      "after": false
+    }],
+    "no-class-assign": 2,
+    "no-confusing-arrow": [2, {
+      "allowParens": true
+    }],
+    "no-const-assign": 2,
+    "no-dupe-class-members": 2,
+    "no-duplicate-imports": 2,
+    "no-new-symbol": 2,
+    "no-restricted-imports": 0,
+    "no-this-before-super": 0,
+    "no-useless-computed-key": 2,
+    "no-useless-constructor": 2,
+    "no-var": 2,
+    "object-shorthand": [2, "always", {
+      "ignoreConstructors": false,
+      "avoidQuotes": true
+    }],
+    "prefer-arrow-callback": [2, {
+      "allowNamedFunctions": false,
+      "allowUnboundThis": true
+    }],
+    "prefer-const": [2, {
+      "destructuring": "any",
+      "ignoreReadBeforeAssign": true
+    }],
+    "prefer-reflect": 0,
+    "no-caller": 2,
+    "prefer-rest-params": 2,
+    "prefer-spread": 2,
+    "prefer-template": 2,
+    "require-yield": 2,
+    "sort-imports": 0,
+    "template-curly-spacing": 2,
+    "yield-star-spacing": [2, "before"],
+    "import/no-unresolved": [0],
+    "import/named": 0,
+    "import/default": 0,
+    "import/namespace": 0,
+    "import/export": 2,
+    "import/no-named-as-default": 0,
+    "import/no-named-as-default-member": 0,
+    "import/no-deprecated": 0,
+    "import/no-extraneous-dependencies": [0, {
+      "devDependencies": false,
+      "optionalDependencies": false
+    }],
+    "import/no-mutable-exports": 2,
+    "import/no-commonjs": 0,
+    "import/no-amd": 2,
+    "import/no-nodejs-modules": 0,
+    "import/imports-first": [2, "absolute-first"],
+    "import/no-duplicates": 2,
+    "import/no-namespace": 0,
+    "import/extensions": [0, "never"],
+    "import/order": [0, {
+      "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
+      "newlines-between": "never"
+    }],
+    "import/newline-after-import": 2,
+    "import/prefer-default-export": 2,
+    "array-bracket-spacing": [2, "never"],
+    "block-spacing": [2, "always"],
+    "brace-style": [2, "1tbs", {
+      "allowSingleLine": true
+    }],
+    "camelcase": [2, {
+      "properties": "always"
+    }],
+    "comma-spacing": [2, {
+      "before": false,
+      "after": true
+    }],
+    "comma-style": [2, "last"],
+    "computed-property-spacing": [2, "never"],
+    "consistent-this": [2, "self"],
+    "eol-last": 2,
+    "func-names": 0,
+    "func-style": [2, "declaration"],
+    "id-blacklist": 0,
+    "id-length": 0,
+    "id-match": 0,
+    "indent": [2, 2],
+    "key-spacing": [2, {
+      "beforeColon": false,
+      "afterColon": true
+    }],
+    "keyword-spacing": [2, {
+      "before": true,
+      "after": true,
+      "overrides": {
+        "return": {
+          "after": true
+        },
+        "throw": {
+          "after": true
+        },
+        "case": {
+          "after": true
+        }
+      }
+    }],
+    "linebreak-style": [2, "unix"],
+    "lines-around-comment": 0,
+    "max-depth": [2, 4],
+    "max-len": [2, 120, {
+      "ignorePattern": "^\\s.+class=\""
+    }],
+    "max-nested-callbacks": [2, 4],
+    "max-params": [1, 4],
+    "max-statements": [1, 10],
+    "max-statements-per-line": [2, {
+      "max": 1
+    }],
+    "new-cap": [2, {
+      "newIsCap": true
+    }],
+    "new-parens": 2,
+    "newline-after-var": 0,
+    "newline-before-return": 2,
+    "newline-per-chained-call": [2, {
+      "ignoreChainWithDepth": 3
+    }],
+    "no-array-constructor": 2,
+    "no-bitwise": 1,
+    "no-continue": 0,
+    "no-inline-comments": 0,
+    "no-lonely-if": 0,
+    "no-mixed-spaces-and-tabs": 2,
+    "no-multiple-empty-lines": [2, {
+      "max": 1,
+      "maxEOF": 1
+    }],
+    "no-negated-condition": 2,
+    "no-nested-ternary": 2,
+    "no-new-object": 2,
+    "no-plusplus": 0,
+    "no-restricted-syntax": [2, "DebuggerStatement", "ForInStatement", "LabeledStatement", "WithStatement"],
+    "no-spaced-func": 2,
+    "no-ternary": 0,
+    "no-trailing-spaces": 2,
+    "no-underscore-dangle": [1],
+    "no-unneeded-ternary": [2, {
+      "defaultAssignment": false
+    }],
+    "no-whitespace-before-property": 2,
+    "object-curly-spacing": [2, "always"],
+    "object-property-newline": [0, {
+      "allowMultiplePropertiesPerLine": true
+    }],
+    "one-var": [2, "never"],
+    "one-var-declaration-per-line": [2, "always"],
+    "operator-assignment": 2,
+    "operator-linebreak": [2, "after"],
+    "padded-blocks": [2, "never"],
+    "quote-props": [2, "as-needed", {
+      "keywords": false,
+      "unnecessary": false,
+      "numbers": false
+    }],
+    "quotes": [2, "single", {
+      "avoidEscape": true
+    }],
+    "require-jsdoc": 0,
+    "semi": [2, "always"],
+    "semi-spacing": [2, {
+      "before": false,
+      "after": true
+    }],
+    "sort-vars": 0,
+    "space-before-blocks": 2,
+    "space-before-function-paren": [2, {
+      "anonymous": "always",
+      "named": "never"
+    }],
+    "space-in-parens": [2, "never"],
+    "space-infix-ops": 2,
+    "space-unary-ops": 0,
+    "spaced-comment": [2],
+    "wrap-regex": 0,
+    "init-declarations": 0,
+    "no-catch-shadow": 2,
+    "no-delete-var": 0,
+    "no-label-var": 2,
+    "no-restricted-globals": 0,
+    "no-shadow": 2,
+    "no-shadow-restricted-names": 2,
+    "no-undef": 2,
+    "no-undef-init": 2,
+    "no-unused-vars": [2, {
+      "vars": "local",
+      "args": "after-used"
+    }],
+    "no-use-before-define": 2,
+    "vue/max-len": ["error", {
+      "code": 120,
+      "ignoreHTMLAttributeValues": true
+  }]
+  }
+}

--- a/lib/potassium/assets/.rubocop.yml
+++ b/lib/potassium/assets/.rubocop.yml
@@ -1,0 +1,515 @@
+require:
+  - rubocop-rspec
+  - rubocop-rails
+  - rubocop-performance
+AllCops:
+  Exclude:
+  - "vendor/**/*"
+  - "db/**/*"
+  - "bin/**/*"
+  TargetRubyVersion: 2.7
+Rails:
+  Enabled: true
+Performance:
+  Enabled: true
+Layout/ParameterAlignment:
+  Description: Align the parameters of a method call if they span more than one line.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-double-indent
+  Enabled: true
+  EnforcedStyle: with_fixed_indentation
+  SupportedStyles:
+  - with_first_parameter
+  - with_fixed_indentation
+Metrics/BlockLength:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Description: Checks style of children classes and modules.
+  Enabled: false
+  EnforcedStyle: nested
+  SupportedStyles:
+  - nested
+  - compact
+Style/CommentAnnotation:
+  Description: Checks formatting of special comments (TODO, FIXME, OPTIMIZE, HACK,
+    REVIEW).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#annotate-keywords
+  Enabled: false
+  Keywords:
+  - TODO
+  - FIXME
+  - OPTIMIZE
+  - HACK
+  - REVIEW
+Naming/FileName:
+  Description: Use snake_case for source file names.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
+  Enabled: false
+  Exclude: []
+Style/FormatString:
+  Description: Enforce the use of Kernel#sprintf, Kernel#format or String#%.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#sprintf
+  Enabled: false
+  EnforcedStyle: format
+  SupportedStyles:
+  - format
+  - sprintf
+  - percent
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/GlobalVars:
+  Description: Do not introduce global variables.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#instance-vars
+  Enabled: false
+  AllowedVariables: []
+Style/GuardClause:
+  Description: Check for conditionals that can be replaced with guard clauses
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
+  Enabled: false
+  MinBodyLength: 1
+Style/IfUnlessModifier:
+  Description: Favor modifier if/unless usage when you have a single-line body.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
+  Enabled: false
+Style/LambdaCall:
+  Description: Use lambda.call(...) instead of lambda.(...).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#proc-call
+  Enabled: false
+  EnforcedStyle: call
+  SupportedStyles:
+  - call
+  - braces
+Style/Next:
+  Description: Use `next` to skip iteration instead of a condition at the end.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
+  Enabled: false
+  EnforcedStyle: skip_modifier_ifs
+  MinBodyLength: 3
+  SupportedStyles:
+  - skip_modifier_ifs
+  - always
+Layout/MultilineOperationIndentation:
+  Description: Checks indentation of binary operations that span more than one line.
+  Enabled: true
+  EnforcedStyle: indented
+  SupportedStyles:
+  - aligned
+  - indented
+Style/MutableConstant:
+  Description: Do not assign mutable objects to constants.
+  Enabled: false
+Style/NumericLiterals:
+  Description: Add underscores to large numeric literals to improve their readability.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics
+  Enabled: false
+  MinDigits: 5
+Style/PercentLiteralDelimiters:
+  Description: Use `%`-literal delimiters consistently
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-literal-braces
+  Enabled: false
+  PreferredDelimiters:
+    "%": "()"
+    "%i": "()"
+    "%q": "()"
+    "%Q": "()"
+    "%r": "{}"
+    "%s": "()"
+    "%w": "()"
+    "%W": "()"
+    "%x": "()"
+Naming/PredicateName:
+  Description: Check the names of predicate methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark
+  Enabled: true
+  NamePrefix:
+  - is_
+  - has_
+  - have_
+  ForbiddenPrefixes:
+  - is_
+Style/RaiseArgs:
+  Description: Checks the arguments passed to raise/fail.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#exception-class-messages
+  Enabled: false
+  EnforcedStyle: exploded
+  SupportedStyles:
+  - compact
+  - exploded
+Style/SignalException:
+  Description: Checks for proper usage of fail and raise.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#fail-method
+  Enabled: false
+  EnforcedStyle: semantic
+  SupportedStyles:
+  - only_raise
+  - only_fail
+  - semantic
+Style/SingleLineMethods:
+  Description: Avoid single-line methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-single-line-methods
+  Enabled: false
+  AllowIfMethodIsEmpty: true
+Style/StringLiterals:
+  Description: Checks if uses of quotes match the configured preference.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
+  Enabled: false
+  EnforcedStyle: double_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
+Style/TrailingCommaInArguments:
+  Description: Checks for trailing comma in argument lists.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
+  Enabled: true
+Style/TrailingCommaInArrayLiteral:
+  Description: Checks for trailing comma in array and hash literals.
+  StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#no-trailing-array-commas
+  Enabled: true
+Style/TrailingCommaInHashLiteral:
+  Description: Checks for trailing comma in array and hash literals.
+  StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#no-trailing-array-commas
+  Enabled: true
+Style/TrivialAccessors:
+  Description: Prefer attr_* methods to trivial readers/writers.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#attr_family
+  Enabled: false
+  ExactNameMatch: false
+  AllowPredicates: false
+  AllowDSLWriters: false
+  AllowedMethods:
+  - to_ary
+  - to_a
+  - to_c
+  - to_enum
+  - to_h
+  - to_hash
+  - to_i
+  - to_int
+  - to_io
+  - to_open
+  - to_path
+  - to_proc
+  - to_r
+  - to_regexp
+  - to_str
+  - to_s
+  - to_sym
+Style/WhileUntilModifier:
+  Description: Favor modifier while/until usage when you have a single-line body.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier
+  Enabled: false
+Style/WordArray:
+  Description: Use %w or %W for arrays of words.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-w
+  Enabled: false
+  MinSize: 0
+  WordRegex: !ruby/regexp /\A[\p{Word}]+\z/
+Style/ExponentialNotation:
+  Enabled: true
+Style/HashEachMethods:
+  Description: Use Hash#each_key and Hash#each_value.
+  Enabled: true
+Style/HashTransformKeys:
+  Description: Prefer `transform_keys` over `each_with_object` and `map`.
+  Enabled: true
+Style/HashTransformValues:
+  Description: Prefer `transform_values` over `each_with_object` and `map`.
+  Enabled: true
+Metrics/AbcSize:
+  Description: A calculated magnitude based on number of assignments, branches, and
+    conditions.
+  Enabled: true
+  Max: 25
+Metrics/BlockNesting:
+  Description: Avoid excessive block nesting
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count
+  Enabled: true
+  Max: 3
+Metrics/ClassLength:
+  Description: Avoid classes longer than 100 lines of code.
+  Enabled: false
+  CountComments: false
+  Max: 100
+Metrics/MethodLength:
+  Description: Avoid methods longer than 15 lines of code.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
+  Enabled: true
+  CountComments: true
+  Max: 15
+  Exclude:
+  - "spec/**/*"
+Metrics/ParameterLists:
+  Description: Avoid long parameter lists.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#too-many-params
+  Enabled: false
+  Max: 5
+  CountKeywordArgs: true
+Lint/AssignmentInCondition:
+  Description: Don't use assignment in conditions.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition
+  Enabled: false
+  AllowSafeAssignment: true
+Layout/LineLength:
+  Description: Limit lines to 100 characters.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#100-character-limits
+  Enabled: true
+  Max: 100
+  AllowURI: true
+  URISchemes:
+  - http
+  - https
+Layout/EndAlignment:
+  Description: Align ends correctly.
+  Enabled: true
+  EnforcedStyleAlignWith: keyword
+  SupportedStylesAlignWith:
+  - keyword
+  - variable
+Layout/DefEndAlignment:
+  Description: Align ends corresponding to defs correctly.
+  Enabled: true
+  EnforcedStyleAlignWith: start_of_line
+  SupportedStylesAlignWith:
+  - start_of_line
+  - def
+Layout/SpaceAroundMethodCallOperator:
+  Description: Checks method call operators to not have spaces around them.
+  Enabled: true
+Style/SymbolArray:
+  Description: Use %i or %I for arrays of symbols.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-i
+  Enabled: false
+Layout/ExtraSpacing:
+  Description: Do not use unnecessary spacing.
+  Enabled: false
+Naming/AccessorMethodName:
+  Description: Check the naming of accessor methods for get_/set_.
+  Enabled: false
+Style/Alias:
+  Description: Use alias_method instead of alias.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#alias-method
+  Enabled: false
+Style/ArrayJoin:
+  Description: Use Array#join instead of Array#*.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#array-join
+  Enabled: false
+Style/AsciiComments:
+  Description: Use only ascii symbols in comments.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#english-comments
+  Enabled: false
+Naming/AsciiIdentifiers:
+  Description: Use only ascii symbols in identifiers.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#english-identifiers
+  Enabled: false
+Style/Attr:
+  Description: Checks for uses of Module#attr.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#attr
+  Enabled: false
+Style/BlockComments:
+  Description: Do not use block comments.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-block-comments
+  Enabled: false
+Style/CaseEquality:
+  Description: Avoid explicit use of the case equality operator(===).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-case-equality
+  Enabled: false
+Style/CharacterLiteral:
+  Description: Checks for uses of character literals.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-character-literals
+  Enabled: false
+Style/ClassVars:
+  Description: Avoid the use of class variables.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-class-vars
+  Enabled: false
+Style/ColonMethodCall:
+  Description: 'Do not use :: for method call.'
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#double-colons
+  Enabled: false
+Style/PreferredHashMethods:
+  Description: Checks for use of deprecated Hash methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-key
+  Enabled: false
+Style/Documentation:
+  Description: Document classes and non-namespace modules.
+  Enabled: false
+Style/DoubleNegation:
+  Description: Checks for uses of double negation (!!).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-bang-bang
+  Enabled: false
+Style/EachWithObject:
+  Description: Prefer `each_with_object` over `inject` or `reduce`.
+  Enabled: false
+Style/EmptyElse:
+  Description: Avoid empty else-clauses.
+  Enabled: true
+Style/EmptyLiteral:
+  Description: Prefer literals to Array.new/Hash.new/String.new.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#literal-array-hash
+  Enabled: false
+Layout/EndOfLine:
+  Description: Use Unix-style line endings.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#crlf
+  Enabled: true
+Style/EvenOdd:
+  Description: Favor the use of Fixnum#even? && Fixnum#odd?
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#predicate-methods
+  Enabled: false
+Lint/FlipFlop:
+  Description: Checks for flip flops
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-flip-flops
+  Enabled: false
+Style/IfWithSemicolon:
+  Description: Do not use if x; .... Use the ternary operator instead.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs
+  Enabled: false
+Style/Lambda:
+  Description: Use the new lambda literal syntax for single-line blocks.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#lambda-multi-line
+  Enabled: false
+Style/LineEndConcatenation:
+  Description: Use \ instead of + or << to concatenate two string literals at line
+    end.
+  Enabled: false
+Style/ModuleFunction:
+  Description: Checks for usage of `extend self` in modules.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#module-function
+  Enabled: false
+Style/MultilineBlockChain:
+  Description: Avoid multi-line chains of blocks.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#single-line-blocks
+  Enabled: false
+Layout/MultilineBlockLayout:
+  Description: Ensures newlines after multiline block do statements.
+  Enabled: false
+Style/NegatedIf:
+  Description: Favor unless over if for negative conditions (or control flow or).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#unless-for-negatives
+  Enabled: false
+Style/NegatedWhile:
+  Description: Favor until over while for negative conditions.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#until-for-negatives
+  Enabled: false
+Style/NilComparison:
+  Description: Prefer x.nil? to x == nil.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#predicate-methods
+  Enabled: false
+Style/OneLineConditional:
+  Description: Favor the ternary operator(?:) over if/then/else/end constructs.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#ternary-operator
+  Enabled: false
+Naming/BinaryOperatorParameterName:
+  Description: When defining binary operators, name the argument other.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#other-arg
+  Enabled: false
+Style/PerlBackrefs:
+  Description: Avoid Perl-style regex back references.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers
+  Enabled: false
+Style/Proc:
+  Description: Use proc instead of Proc.new.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#proc
+  Enabled: false
+Style/SelfAssignment:
+  Description: Checks for places where self-assignment shorthand should have been
+    used.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#self-assignment
+  Enabled: false
+Layout/SpaceBeforeFirstArg:
+  Description: Put a space between a method name and the first argument in a method
+    call without parentheses.
+  Enabled: true
+Layout/SpaceAroundOperators:
+  Description: Use spaces around operators.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
+  Enabled: true
+Layout/SpaceInsideParens:
+  Description: No spaces after ( or before ).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-spaces-braces
+  Enabled: true
+Style/SpecialGlobalVars:
+  Description: Avoid Perl-style global variables.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms
+  Enabled: false
+Style/VariableInterpolation:
+  Description: Don't interpolate global, instance and class variables directly in
+    strings.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#curlies-interpolate
+  Enabled: false
+Style/WhenThen:
+  Description: Use when x then ... for one-line cases.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#one-line-cases
+  Enabled: false
+Lint/AmbiguousOperator:
+  Description: Checks for ambiguous operators in the first argument of a method invocation
+    without parentheses.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-as-args
+  Enabled: false
+Lint/AmbiguousRegexpLiteral:
+  Description: Checks for ambiguous regexp literals in the first argument of a method
+    invocation without parenthesis.
+  Enabled: false
+Layout/BlockAlignment:
+  Description: Align block ends correctly.
+  Enabled: true
+Layout/ConditionPosition:
+  Description: Checks for condition placed in a confusing position relative to the
+    keyword.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#same-line-condition
+  Enabled: false
+Lint/DeprecatedClassMethods:
+  Description: Check for deprecated class method calls.
+  Enabled: false
+Lint/ElseLayout:
+  Description: Check for odd code arrangement in an else block.
+  Enabled: false
+Lint/SuppressedException:
+  Description: Don't suppress exception.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
+  Enabled: false
+Lint/LiteralAsCondition:
+  Description: Checks of literals used in conditions.
+  Enabled: false
+Lint/LiteralInInterpolation:
+  Description: Checks for literals used in interpolation.
+  Enabled: false
+Lint/Loop:
+  Description: Use Kernel#loop with break rather than begin/end/until or begin/end/while
+    for post-loop tests.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#loop-with-break
+  Enabled: false
+Lint/ParenthesesAsGroupedExpression:
+  Description: Checks for method calls with a space before the opening parenthesis.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-no-spaces
+  Enabled: false
+Lint/RequireParentheses:
+  Description: Use parentheses in the method call to avoid confusion about precedence.
+  Enabled: false
+Lint/UnderscorePrefixedVariableName:
+  Description: Do not use prefix `_` for a variable that is used.
+  Enabled: false
+Lint/Void:
+  Description: Possible use of operator/literal/variable in void context.
+  Enabled: false
+Lint/RaiseException:
+  Description: Checks for `raise` or `fail` statements which are raising `Exception` class.
+  Enabled: true
+Lint/StructNewOverride:
+  Description: Disallow overriding the `Struct` built-in methods via `Struct.new`.
+  Enabled: true
+Rails/Delegate:
+  Description: Prefer delegate method for delegations.
+  Enabled: false
+Performance/RedundantBlockCall:
+  Description: Use `yield` instead of `block.call`.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#proccall-vs-yield-code
+  Enabled: false
+RSpec/MultipleExpectations:
+  Max: 5
+RSpec/NestedGroups:
+  Max: 5
+RSpec/ExampleLength:
+  Max: 10
+RSpec/LetSetup:
+  Enabled: false
+RSpec/ExpectChange:
+  Enabled: true
+  EnforcedStyle: block

--- a/lib/potassium/assets/.stylelintrc.json
+++ b/lib/potassium/assets/.stylelintrc.json
@@ -1,0 +1,46 @@
+{
+  "rules": {
+    "declaration-bang-space-before": "always",
+    "declaration-bang-space-after": "never",
+    "declaration-property-value-blacklist": {
+      "/^border/": ["none"]
+    },
+    "color-named": "never",
+    "declaration-block-no-duplicate-properties": true,
+    "rule-empty-line-before": ["always-multi-line", {
+      "except": ["after-single-line-comment", "first-nested"]
+    }],
+    "block-no-empty": true,
+    "no-missing-end-of-source-newline": true,
+    "color-hex-length": "short",
+    "color-hex-case": "lower",
+    "color-no-invalid-hex": true,
+    "selector-max-id": 0,
+    "declaration-no-important": true,
+    "indentation": 2,
+    "number-leading-zero": "never",
+    "no-duplicate-selectors": true,
+    "max-nesting-depth": 3,
+    "selector-pseudo-element-colon-notation": "double",
+    "selector-no-qualifying-type": true,
+    "shorthand-property-no-redundant-values": true,
+    "declaration-block-semicolon-newline-after": "always-multi-line",
+    "selector-list-comma-newline-after": "always",
+    "function-comma-space-after": "always-single-line",
+    "declaration-colon-space-after": "always",
+    "declaration-colon-space-before": "never",
+    "block-opening-brace-space-before": "always",
+    "function-parentheses-space-inside": "never",
+    "string-quotes": "single",
+    "declaration-block-trailing-semicolon": "always",
+    "no-eol-whitespace": true,
+    "number-no-trailing-zeros": true,
+    "function-url-quotes": "always",
+    "property-no-vendor-prefix": true,
+    "selector-no-vendor-prefix": true,
+    "media-feature-name-no-vendor-prefix": true,
+    "at-rule-no-vendor-prefix": true,
+    "value-no-vendor-prefix": true,
+    "length-zero-no-unit": true
+  }
+}

--- a/lib/potassium/assets/README.yml
+++ b/lib/potassium/assets/README.yml
@@ -75,10 +75,17 @@ readme:
     style_guide:
       title: "Style Guides"
       body: |
-        The style guides are enforced through a self hosted version of [Hound CI](http://monkeyci.platan.us). The style configuration can also be used locally
-        in development runing `rubocop` or just using the rubocop integration for your text editor of choice.
+        Style guides are enforced through a CircleCI [job](.circleci/config.yml) with [reviewdog](https://github.com/reviewdog/reviewdog) as a reporter, using per-project dependencies and style configurations.
+        Please note that this reviewdog implementation requires a GitHub user token to comment on pull requests. A token can be generated [here](https://github.com/settings/tokens), and it should have at least the `repo` option checked.
+        The included `config.yml` assumes your CircleCI organization has a context named `org-global` with the required token under the environment variable `REVIEWDOG_GITHUB_API_TOKEN`.
 
-        You can add custom rules to this project just adding them to the `.ruby-style.yml` file.
+        The project comes bundled with configuration files available in this repository.
+
+        Linting dependencies like `rubocop` or `rubocop-rspec` must be locked in your `Gemfile`. Similarly, packages like `eslint` or `eslint-plugin-vue` must be locked in your `package.json`.
+
+        You can add or modify rules by editing the [`.rubocop.yml`](.rubocop.yml), [`.eslintrc.json`](.eslintrc.json) or [`.stylelintrc.json`](.stylelintrc.json) files.
+
+        You can (and should) use linter integrations for your text editor of choice, using the project's configuration.
     mailing:
       title: "Sending Emails"
       body: |

--- a/lib/potassium/recipes/style.rb
+++ b/lib/potassium/recipes/style.rb
@@ -1,12 +1,30 @@
 class Recipes::Style < Rails::AppBuilder
   def create
-    append_to_file ".gitignore", ".rubocop.yml\n"
-    append_to_file ".gitignore", ".eslintrc.json\n"
-    append_to_file ".gitignore", ".sscs-lint.yml\n"
+    add_linters
+    add_config_files
     add_readme_header :style_guide
   end
 
   def install
     create
+  end
+
+  private
+
+  def add_linters
+    gather_gems(:development, :test) do
+      gather_gem 'rubocop', '~> 0.82.0'
+      gather_gem 'rubocop-performance'
+      gather_gem 'rubocop-rails'
+      gather_gem 'rubocop-rspec'
+    end
+    run 'bin/yarn add --dev stylelint eslint eslint-plugin-import'
+    run 'bin/yarn add --dev eslint-plugin-vue' if selected?(:front_end, :vue)
+  end
+
+  def add_config_files
+    copy_file '../assets/.rubocop.yml', '.rubocop.yml'
+    copy_file '../assets/.eslintrc.json', '.eslintrc.json'
+    copy_file '../assets/.stylelintrc.json', '.stylelintrc.json'
   end
 end


### PR DESCRIPTION
### Description
This PR adds linting with reviewdog in CircleCI to new projects. To accomplish this, config files for the three used linters are now part of projects. Also `rubocop`, `eslint` and `stylelint` gems and libraries are locked into the dependencies alongside their plugins.

#### Details
- All 3 config files are now part of potassium assets and bundled with every new project. 
- Rubocop rules were updated to the last available version (`0.82.0`).
- The CI config adds a linting job that runs in parallel and uses reviewdog to report violations to github.