### PR TITLE
fix(front-end): remove manual insertion of js pack tag

### DIFF
--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -50,9 +50,7 @@ class Recipes::FrontEnd < Rails::AppBuilder
     remove_file "app/javascript/packs/hello_vue.js"
     create_file application_js, application_js_content, force: true
 
-    js_pack_tag = "\n    <%= javascript_pack_tag 'application' %>\n"
     layout_file = "app/views/layouts/application.html.erb"
-    insert_into_file layout_file, js_pack_tag, after: "<%= csrf_meta_tags %>"
     insert_into_file(
       layout_file,
       "<div id=\"vue-app\">\n      <app></app>\n      ",

--- a/spec/features/front_end_spec.rb
+++ b/spec/features/front_end_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe "Front end" do
       expect(layout_file).to include('id="vue-app"')
     end
 
+    it "creates a project with only one js pack tag" do
+      expect(layout_file.scan("javascript_pack_tag").length).to eq(1)
+    end
+
     it "creates a vue project with client css" do
       expect(application_js_file).to include("import '../css/application.css';")
       expect(layout_file).to include("<%= stylesheet_pack_tag 'application' %>")


### PR DESCRIPTION
Since webpacker is the default js compiler of Rails, new projects [already come with a `javascript_pack_tag` in the layout file](https://github.com/rails/rails/commit/4838c1716a0340137d858fab49bf460e23be5a4b#diff-eacee044d2d703bce71ec1447308e9beR13). 
This removes the manual insertion of the tag in the frontend recipe.

Fixes #295 