### PR TITLE
Shrine fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Fix:
+  - Fix shrine issues related to configuration and uploader validation [#302](https://github.com/platanus/potassium/pull/302)
+
 ## 6.0.0
 
 Features:

--- a/lib/potassium/assets/app/uploaders/base_uploader.rb
+++ b/lib/potassium/assets/app/uploaders/base_uploader.rb
@@ -2,10 +2,8 @@ class BaseUploader < Shrine
   plugin :validation_helpers
 
   Attacher.validate do
-    validate_mime_type allowed_types
+    validate_mime_type store.allowed_types
   end
-
-  private
 
   def allowed_types
     raise NotImplementedError

--- a/lib/potassium/assets/config/shrine.rb
+++ b/lib/potassium/assets/config/shrine.rb
@@ -24,7 +24,10 @@ elsif Rails.env.production?
 else
   require 'shrine/storage/memory'
 
-  Shrine.storages[:store] = Shrine::Storage::Memory.new
+  Shrine.storages = {
+    cache: Shrine::Storage::Memory.new,
+    store: Shrine::Storage::Memory.new
+  }
 end
 
 Shrine.plugin :activerecord

--- a/lib/potassium/recipes/file_storage.rb
+++ b/lib/potassium/recipes/file_storage.rb
@@ -43,6 +43,7 @@ class Recipes::FileStorage < Rails::AppBuilder
     copy_file('../assets/config/shrine.rb', 'config/initializers/shrine.rb', force: true)
     copy_file('../assets/app/uploaders/image_uploader.rb', 'app/uploaders/image_uploader.rb')
     copy_file('../assets/app/uploaders/base_uploader.rb', 'app/uploaders/base_uploader.rb')
+    append_to_file('.gitignore', "/public/uploads\n")
   end
 
   def common_setup

--- a/spec/features/file_storage_spec.rb
+++ b/spec/features/file_storage_spec.rb
@@ -66,5 +66,10 @@ RSpec.describe "File Storage" do
       content = IO.read("#{project_path}/.env.development")
       expect(content).to include("S3_BUCKET=")
     end
+
+    it "adds filestorage path to gitignore" do
+      content = IO.read("#{project_path}/.gitignore")
+      expect(content).to include("/public/uploads")
+    end
   end
 end


### PR DESCRIPTION
Fixes a couple of issues that arrise when using shrine as file storage:

- In the `Attacher.validate` block `allowed_type` was being accessed directly, but it wasn't available in that context. Now it is accessed through the `store` (instance of uploader)
- Define cache storage in test env
- Add path for saved files in dev env to `.gitignore`