### PR TITLE
feat(.eslintrc.json): add overrides rules for files outside of app/

### DIFF
--- a/lib/potassium/assets/.eslintrc.json
+++ b/lib/potassium/assets/.eslintrc.json
@@ -339,5 +339,14 @@
       "code": 120,
       "ignoreHTMLAttributeValues": true
   }]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/*.js"],
+      "excludedFiles": "app/**/*.js",
+      "env": {
+        "node": true
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Objective
Add `"node": true` for the files outside of the folder `/app`.

## Description
- This avoids the raise of errors for methods like `require` or `model.export` that are used in most configurations files.
