### PR TITLE
Node version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Features:
+  - Check node version before project creation [#305](https://github.com/platanus/potassium/pull/305)
+
 Fix:
   - Fix shrine issues related to configuration and uploader validation [#302](https://github.com/platanus/potassium/pull/302)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Use the `potassium create` command to create a new project:
 
     $ potassium create <project-name>
 
-> It's important to note that it will perform a version check before running to ensure that you're using the latest potassium. Also, if you feel that it's too slow, you may need to update rubygems: `gem update --system`.
+> Please note:
+> 1. Potassium will perform a version check before running to ensure that you are using the latest potassium.
+> 2. If you feel that it's too slow, you may need to update rubygems: `gem update --system`.
+> 3. Potassium uses node under the hood, so a check will also be performed to ensure you are running the supported version.
 
 ### Adding recipes to an existing project
 

--- a/lib/potassium/cli/commands/create.rb
+++ b/lib/potassium/cli/commands/create.rb
@@ -3,37 +3,38 @@ require 'potassium/cli_options'
 module Potassium::CLI
   extend Potassium::CliOptions
 
-  desc "Create a new Potassium Rails project."
+  desc 'Create a new Potassium Rails project.'
   arg 'app_path'
   command :create do |c|
-    c.default_desc "Create a new project."
-    c.switch "version-check",
-      default_value: true,
-      desc: "Performs a version check before running.",
-      negatable: true
+    c.default_desc 'Create a new project.'
+    c.switch 'version-check',
+             default_value: true,
+             desc: 'Performs a version check before running.',
+             negatable: true
+    c.switch 'node-version-check',
+             default_value: true,
+             desc: 'Performs a node version check before running.',
+             negatable: true
 
     create_options.each { |opts| c.send(opts.delete(:type), opts.delete(:name), opts) }
 
     c.action do |_global_options, options, _args|
-      require "potassium/newest_version_ensurer"
+      require 'potassium/newest_version_ensurer'
+      require 'potassium/node_version_ensurer'
+      require 'potassium/generators/application'
+      require 'potassium/template_finder'
 
-      begin_creation = -> do
-        require "potassium/generators/application"
-        require "potassium/template_finder"
-
+      begin
+        Potassium::NewestVersionEnsurer.new.ensure! if options['version-check']
+        Potassium::NodeVersionEnsurer.new.ensure! if options['node-version-check']
         template_finder = Potassium::TemplateFinder.new
         template = template_finder.default_template
         template.cli_options = options
         template.source_paths << Rails::Generators::AppGenerator.source_root
         ARGV.push('--skip-webpack-install', '--skip-bundle')
         template.start
-      end
-
-      if options["version-check"]
-        ensurer = Potassium::NewestVersionEnsurer.new
-        ensurer.ensure(&begin_creation)
-      else
-        begin_creation.call
+      rescue VersionError => e
+        print "\nError: #{e.message}" # rubocop:disable Rails/Output
       end
     end
   end

--- a/lib/potassium/cli/commands/create.rb
+++ b/lib/potassium/cli/commands/create.rb
@@ -7,15 +7,6 @@ module Potassium::CLI
   arg 'app_path'
   command :create do |c|
     c.default_desc 'Create a new project.'
-    c.switch 'version-check',
-             default_value: true,
-             desc: 'Performs a version check before running.',
-             negatable: true
-    c.switch 'node-version-check',
-             default_value: true,
-             desc: 'Performs a node version check before running.',
-             negatable: true
-
     create_options.each { |opts| c.send(opts.delete(:type), opts.delete(:name), opts) }
 
     c.action do |_global_options, options, _args|

--- a/lib/potassium/cli_options.rb
+++ b/lib/potassium/cli_options.rb
@@ -1,6 +1,22 @@
 module Potassium::CliOptions # rubocop:disable Metrics/ModuleLength
   CREATE_OPTIONS = [
     {
+      type: :switch,
+      name: 'version-check',
+      desc: 'Performs a version check before running.',
+      negatable: true,
+      default_value: true,
+      default_test_value: true
+    },
+    {
+      type: :switch,
+      name: 'node-version-check',
+      desc: 'Performs a node version check before running.',
+      negatable: true,
+      default_value: true,
+      default_test_value: true
+    },
+    {
       type: :flag,
       name: [:db, :database],
       desc: "Decides which database to use. Available: mysql, postgresql, none",

--- a/lib/potassium/newest_version_ensurer.rb
+++ b/lib/potassium/newest_version_ensurer.rb
@@ -1,51 +1,34 @@
-require "term/ansicolor"
-require "gems"
-require "semantic"
-require "potassium/text_spinner"
+require 'gems'
+require 'semantic'
+require 'potassium/text_spinner'
+
+class VersionError < StandardError
+end
 
 module Potassium
   class NewestVersionEnsurer
-    include Term::ANSIColor
-
-    def initialize(current_version = Potassium::VERSION)
-      self.current_version = Semantic::Version.new(current_version)
+    def initialize
+      self.installed_version = Semantic::Version.new(Potassium::VERSION)
       self.text_spinner = Potassium::TextSpinner.new
     end
 
-    def ensure(&success_block)
-      spin_text("Checking your Potassium installation") { latest_version }
+    def ensure!
+      spin_text('Checking your Potassium installation') { published_version }
 
-      self.latest_version = Semantic::Version.new(
-        Gems.versions("potassium").first["number"]
-      )
-
-      if latest_version <= current_version
-        up_to_date
-        success_block.call
-      else
-        please_update
-      end
+      self.published_version = Semantic::Version.new(Gems.versions('potassium').first['number'])
+      raise VersionError.new(update_message) if published_version > installed_version
     end
 
     private
 
-    attr_accessor :latest_version, :current_version, :text_spinner
+    attr_accessor :published_version, :installed_version, :text_spinner
 
-    def up_to_date
-      puts green("\nYour Potassium installation is up to date.")
-    end
-
-    def please_update
-      puts red("\nYour Potassium installation is not up to date.")
-      puts red("Found: #{current_version}")
-      puts red("Expected: #{latest_version}\n")
-      print white("Please run: ")
-      print green("gem update potassium ")
-      print white("to upgrade your potassium installation.\n\n")
-      print white("If you really need to run this outdated version of potassium anyway, ")
-      print white("re-run this command with the ")
-      print black("--no-version-check")
-      puts white(" flag.")
+    def update_message
+      <<~HERE
+        Your potassium installation is not up to date.
+        The last available version is #{published_version} while the running version is #{installed_version}.
+        If you really need to run this outdated version of potassium, re-run this command with the `--no-version-check` flag.
+      HERE
     end
 
     def spin_text(message, &block)

--- a/lib/potassium/node_version_ensurer.rb
+++ b/lib/potassium/node_version_ensurer.rb
@@ -1,0 +1,30 @@
+module Potassium
+  class NodeVersionEnsurer
+    def ensure!
+      raise VersionError.new(install_message) if installed_node_version.nil?
+      raise VersionError.new(update_message) if Potassium::NODE_VERSION != installed_node_version
+    end
+
+    private
+
+    def installed_node_version
+      node_version = `node -v 2>&1`
+      return node_version.delete('^[0-9\.]').split('.').first if $?.success?
+    end
+
+    def install_message
+      <<~HERE
+        Node doesn't appear to be installed.
+        Please make sure you have node #{Potassium::NODE_VERSION} installed.
+      HERE
+    end
+
+    def update_message
+      <<~HERE
+        An unsupported version of node was found.
+        Please make sure you have node #{Potassium::NODE_VERSION} installed. Newer versions may work but potassium only supports that one.
+        If you really need to run potassium with a different version of node, re-run this command with the `--no-node-version-check` flag.
+      HERE
+    end
+  end
+end


### PR DESCRIPTION
### Description
This PR adds a version check for the node version. Node is a dependency for potassium and project creation often broke due to node incompatibilities. 

#### Details
- The node version check is performed and communicated via exceptions. It can be disabled (at users own risk, for example to use a newer version of node) via the `--no-node-version-check` flag.
- The way the potassium version was checked is also modified to fit the new exception-based flow.