### PR TITLE
feat(dependencies): bump rake in development for security update

### DIFF
--- a/potassium.gemspec
+++ b/potassium.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "pry", "~> 0.10.3"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.4.0"
   spec.add_development_dependency "rspec_junit_formatter"
   spec.add_development_dependency "rubocop", Potassium::RUBOCOP_VERSION


### PR DESCRIPTION
Addressing [this](https://github.com/platanus/potassium/network/alert/potassium.gemspec/rake/open)