### PR TITLE
fix(config/puma): replace rails .day method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
 Fix:
   - Fix shrine issues related to configuration and uploader validation [#302](https://github.com/platanus/potassium/pull/302)
   - Fix database recipe not running recommended generator for strong_migrations gem [#310](https://github.com/platanus/potassium/pull/310)
+  - Fix puma config that was causing it to crash on server start while on development [#313](https://github.com/platanus/potassium/pull/313)
 
 ## 6.0.0
 

--- a/lib/potassium/assets/config/puma.rb
+++ b/lib/potassium/assets/config/puma.rb
@@ -24,7 +24,7 @@ rack_env = ENV.fetch("RACK_ENV", "development")
 environment rack_env
 
 # Set 1 day timeout for workers while developing
-worker_timeout 1.day.seconds.to_i if rack_env == "development"
+worker_timeout 24 * 60 * 60 if rack_env == "development"
 
 on_worker_boot do
   # Worker specific setup for Rails 4.1+


### PR DESCRIPTION
When puma is launching rails hasn't had the chance to overload the integers with the .day method