### PR TITLE
GitHub octokit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features:
   - Disable observers in test environment [#319](https://github.com/platanus/potassium/pull/319)
   - Allow user to select custom Github repository [#318](https://github.com/platanus/potassium/pull/318)
   - Add pull request template to github enabled projects [#320](https://github.com/platanus/potassium/pull/320)
+  - Use a Ruby gem instead of hub to create Github repositories [#323](https://github.com/platanus/potassium/pull/323)
 
 Fix:
   - Fix shrine issues related to configuration and uploader validation [#302](https://github.com/platanus/potassium/pull/302)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The following optional integrations are also added:
   and [Sendgrid](https://github.com/platanus/send_grid_mailer) with recipient interceptor support
 - [Sentry](https://sentry.io) to monitor exceptions and errors
 - [Vue.js](https://vuejs.org) or [Angular 2](https://angular.io/) for frontend development
-- Creates the Github repository of your choice for the project (it uses `hub` under the hood). A local git repository will always be created.
+- Creates the Github repository of your choice for the project. A local git repository will always be created.
 
 A few more things are added to the project:
 

--- a/lib/potassium/cli_options.rb
+++ b/lib/potassium/cli_options.rb
@@ -124,7 +124,15 @@ module Potassium::CliOptions # rubocop:disable Metrics/ModuleLength
       name: "github_private",
       desc: "Whether the github repository is private or not",
       negatable: true,
-      default_value: false,
+      default_value: "none",
+      default_test_value: false
+    },
+    {
+      type: :switch,
+      name: "github_has_org",
+      desc: "Whether the github repository should belong to an organization",
+      negatable: true,
+      default_value: "none",
       default_test_value: false
     },
     {
@@ -138,6 +146,13 @@ module Potassium::CliOptions # rubocop:disable Metrics/ModuleLength
       type: :flag,
       name: "github_name",
       desc: "The github repository name",
+      default_value: "none",
+      default_test_value: "none"
+    },
+    {
+      type: :flag,
+      name: "github_access_token",
+      desc: "Github personal access token used to auth to Github API",
       default_value: "none",
       default_test_value: "none"
     },
@@ -162,6 +177,14 @@ module Potassium::CliOptions # rubocop:disable Metrics/ModuleLength
       name: :front_end,
       desc: "Decides which front-end framework to use. Available: Vue, Angular 2, None",
       default_test_value: "None"
+    },
+    {
+      type: :switch,
+      name: "test",
+      desc: "Whether or not it is a test project creation",
+      negatable: true,
+      default_value: false,
+      default_test_value: true
     }
   ]
 

--- a/lib/potassium/recipes/github.rb
+++ b/lib/potassium/recipes/github.rb
@@ -18,7 +18,7 @@ class Recipes::Github < Rails::AppBuilder
   def create
     return unless selected?(:github_repo)
 
-    github_repo_create
+    create_github_repo
     copy_file '../assets/.github/pull_request_template.md', '.github/pull_request_template.md'
   end
 
@@ -51,7 +51,7 @@ class Recipes::Github < Rails::AppBuilder
     set(:github_repo_name, repo_name)
   end
 
-  def github_repo_create
+  def create_github_repo
     options = { private: get(:github_repo_private) }
     options[:organization] = get(:github_org) if get(:github_has_org)
     repo_name = get(:github_repo_name)

--- a/lib/potassium/recipes/github.rb
+++ b/lib/potassium/recipes/github.rb
@@ -1,3 +1,5 @@
+require 'octokit'
+
 class Recipes::Github < Rails::AppBuilder
   def ask
     github_repo_create = answer(:github) do
@@ -8,30 +10,79 @@ class Recipes::Github < Rails::AppBuilder
   end
 
   def setup_repo
-    github_repo_private = answer(:github_private) do
-      Ask.confirm('Should the repository be private?')
-    end
-    github_repo_organization = answer(:github_org) do
-      Ask.input('What is the organization or user for this repository?', default: 'platanus')
-    end
-    github_repo_name = answer(:github_name) do
-      Ask.input('What is the name for this repository?', default: get(:dasherized_app_name))
-    end
-    set(:github_repo_name, "#{github_repo_organization}/#{github_repo_name}")
-    set(:github_repo_private, github_repo_private)
+    setup_repo_private
+    setup_repo_org
+    setup_repo_name
   end
 
   def create
     return unless selected?(:github_repo)
 
-    github_repo_create(get(:github_repo_name), get(:github_repo_private))
+    github_repo_create
     copy_file '../assets/.github/pull_request_template.md', '.github/pull_request_template.md'
   end
 
   private
 
-  def github_repo_create(repo_name, private_repo = false)
-    flag = private_repo ? "-p" : ""
-    run "hub create #{flag} #{repo_name}"
+  def setup_repo_private
+    repo_private = answer(:github_private) do
+      Ask.confirm('Should the repository be private?')
+    end
+    set(:github_repo_private, repo_private)
+  end
+
+  def setup_repo_org
+    has_organization = answer(:github_has_org) do
+      Ask.confirm('Is this repo for a Github organization?')
+    end
+    set(:github_has_org, has_organization)
+    if has_organization
+      repo_organization = answer(:github_org) do
+        Ask.input('What is the organization for this repository?', default: 'platanus')
+      end
+      set(:github_org, repo_organization)
+    end
+  end
+
+  def setup_repo_name
+    repo_name = answer(:github_name) do
+      Ask.input('What is the name for this repository?', default: get(:dasherized_app_name))
+    end
+    set(:github_repo_name, repo_name)
+  end
+
+  def github_repo_create
+    options = { private: get(:github_repo_private) }
+    options[:organization] = get(:github_org) if get(:github_has_org)
+    repo_name = get(:github_repo_name)
+
+    begin
+      github_client.create_repository(repo_name, options)
+    rescue Octokit::Unauthorized
+      retry if retry_create_repo
+    end
+  end
+
+  def retry_create_repo
+    puts "Bad credentials, information on Personal Access Tokens here:"
+    puts "https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token"
+    puts "Make sure to give repo access to the personal access token"
+    Ask.confirm("Do you want to retry?")
+  end
+
+  def github_client
+    access_token = answer(:github_access_token) do
+      Ask.input('Enter a GitHub personal access token', password: true)
+    end
+    octokit_client.new(access_token: access_token)
+  end
+
+  def octokit_client
+    if answer(:test)
+      require_relative '../../../spec/support/fake_octokit'
+      FakeOctokit
+    else
+      Octokit::Client
+    end
   end
 end

--- a/potassium.gemspec
+++ b/potassium.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "gli", "~> 2.12.2"
   spec.add_runtime_dependency "inquirer", "~> 0.2"
   spec.add_runtime_dependency "levenshtein", "~> 0.2"
+  spec.add_runtime_dependency "octokit", "~> 4.18"
   spec.add_runtime_dependency "rails", Potassium::RAILS_VERSION
   spec.add_runtime_dependency "semantic", "~> 1.4"
 end

--- a/spec/features/github_spec.rb
+++ b/spec/features/github_spec.rb
@@ -1,8 +1,9 @@
 require "spec_helper"
 
 RSpec.describe "GitHub" do
-  let(:github_org) { "platanus" }
+  let(:org_name) { "platanus" }
   let(:repo_name) { PotassiumTestHelpers::APP_NAME.dasherize }
+  let(:access_token) { "1234" }
   let(:pr_template_file) { IO.read("#{project_path}/.github/pull_request_template.md") }
 
   before do
@@ -14,11 +15,12 @@ RSpec.describe "GitHub" do
     create_dummy_project(
       "github" => true,
       "github_private" => false,
-      "github_org" => github_org,
-      "github_name" => repo_name
+      "github_has_org" => false,
+      "github_name" => repo_name,
+      "github_access_token" => access_token
     )
 
-    expect(FakeGithub).to have_created_repo("#{github_org}/#{repo_name}")
+    expect(FakeOctokit).to have_created_repo(repo_name)
     expect(pr_template_file).to include('Contexto')
   end
 
@@ -26,11 +28,40 @@ RSpec.describe "GitHub" do
     create_dummy_project(
       "github" => true,
       "github_private" => true,
-      "github_org" => github_org,
-      "github_name" => repo_name
+      "github_has_org" => false,
+      "github_name" => repo_name,
+      "github_access_token" => access_token
     )
 
-    expect(FakeGithub).to have_created_private_repo("#{github_org}/#{repo_name}")
+    expect(FakeOctokit).to have_created_private_repo(repo_name)
+    expect(pr_template_file).to include('Contexto')
+  end
+
+  it "creates the github repository for the organization" do
+    create_dummy_project(
+      "github" => true,
+      "github_private" => false,
+      "github_has_org" => true,
+      "github_org" => org_name,
+      "github_name" => repo_name,
+      "github_access_token" => access_token
+    )
+
+    expect(FakeOctokit).to have_created_repo_for_org(repo_name, org_name)
+    expect(pr_template_file).to include('Contexto')
+  end
+
+  it "creates the private github repository for the organization" do
+    create_dummy_project(
+      "github" => true,
+      "github_private" => true,
+      "github_has_org" => true,
+      "github_org" => org_name,
+      "github_name" => repo_name,
+      "github_access_token" => access_token
+    )
+
+    expect(FakeOctokit).to have_created_private_repo_for_org(repo_name, org_name)
     expect(pr_template_file).to include('Contexto')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,5 +33,6 @@ RSpec.configure do |config|
   config.before(:each) do
     FakeGithub.clear!
     FakeHeroku.clear!
+    FakeOctokit.clear!
   end
 end

--- a/spec/support/fake_octokit.rb
+++ b/spec/support/fake_octokit.rb
@@ -1,0 +1,31 @@
+class FakeOctokit
+  RECORDER = File.expand_path(File.join('..', '..', 'tmp', 'octokit'), File.dirname(__FILE__))
+
+  def initialize(options); end
+
+  def create_repository(repo_name, options)
+    File.open(RECORDER, 'a') do |file|
+      file.write "#{repo_name}, #{options.map { |key, value| "#{key}: #{value}" }}"
+    end
+  end
+
+  def self.clear!
+    FileUtils.rm_rf RECORDER
+  end
+
+  def self.has_created_repo?(repo_name)
+    File.read(RECORDER).include? repo_name
+  end
+
+  def self.has_created_private_repo?(repo_name)
+    has_created_repo?(repo_name) && File.read(RECORDER).include?("private: true")
+  end
+
+  def self.has_created_repo_for_org?(repo_name, org_name)
+    has_created_repo?(repo_name) && File.read(RECORDER).include?("organization: #{org_name}")
+  end
+
+  def self.has_created_private_repo_for_org?(repo_name, org_name)
+    has_created_private_repo?(repo_name) && has_created_repo_for_org?(repo_name, org_name)
+  end
+end


### PR DESCRIPTION
**Description**
This PR replaces the use of hub to create repositories with usage of the Github API using the Octokit gem.

The downside of this approach is that the user must enter a[ Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) to authenticate. An alternative would be to keep using hub, but if hub fails to use this as a second approach.

Closes #238 