### PR TITLE
chore(): remove rails_stdout_logging gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Fixes
+  - Remove rails_stdout_logging gem because it is no longer needed after Rails 5 and it was generating a deprecation warning [#325](https://github.com/platanus/potassium/pull/325)
+
 ## 6.4.0
 
 Features

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ The optional API support includes:
 
 When you choose to deploy to heroku a few extra things are added for the project.
 
-  - Adds the [Rails Stdout Logging][logging-gem] gem to configure the app to log to standard out, which is how [Heroku's logging][heroku-logging] works
   - Adds a [Procfile][procfile] to define the processes to run in heroku
   - Setup continuous integration using docker and herokuish to maintain better parity between testing and production environments
   - Adds a `bin/release` file with the release phase script to run specific tasks before the app is deployed completely, for example `rails db:migrate:with_data`
@@ -129,7 +128,6 @@ Go to https://circleci.com/add-projects, choose the repository from the list and
 
 In order to enable code linting via CircleCI and ReviewDog, you need to activate the **Only build pull requests** option under the `Advanced settings` section for your project.
 
-[logging-gem]: https://github.com/heroku/rails_stdout_logging
 [heroku-logging]: https://devcenter.heroku.com/articles/logging#writing-to-your-log
 [procfile]: https://devcenter.heroku.com/articles/procfile
 [heroku-buildpack-ruby-version]: http://github.com/platanus/heroku-buildpack-ruby-version

--- a/lib/potassium/recipes/heroku.rb
+++ b/lib/potassium/recipes/heroku.rb
@@ -24,14 +24,13 @@ class Recipes::Heroku < Rails::AppBuilder
   end
 
   def installed?
-    gem_exists?(/rails_stdout_logging/)
+    gem_exists?(/heroku-stage/)
   end
 
   private
 
   def add_heroku
     gather_gems(:production) do
-      gather_gem('rails_stdout_logging')
       gather_gem('heroku-stage')
     end
 

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe "Heroku" do
     create_dummy_project("heroku" => true)
     app_name = PotassiumTestHelpers::APP_NAME.dasherize
 
-    expect(FakeHeroku).to(
-      have_gem_included(project_path, "rails_stdout_logging")
-    )
-
     procfile_path = "#{project_path}/Procfile"
     procfile = IO.read(procfile_path)
 


### PR DESCRIPTION
In this PR the `rails_stdout_logging` is removed from the `heroku` recipe as it isn't needed anymore (since Rails 5) and it was generating a Deprecation Warning.

More info here:
[https://github.com/heroku/rails_stdout_logging#rails-5](https://github.com/heroku/rails_stdout_logging#rails-5)