### PR TITLE
feat(background_processor): include redis docker configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
   - Allow user to select custom Github repository [#318](https://github.com/platanus/potassium/pull/318)
   - Add pull request template to github enabled projects [#320](https://github.com/platanus/potassium/pull/320)
   - Use a Ruby gem instead of hub to create Github repositories [#323](https://github.com/platanus/potassium/pull/323)
+  - Add dockerized redis configuration when using background processor [#329](https://github.com/platanus/potassium/pull/329)
 
 Fix:
   - Fix shrine issues related to configuration and uploader validation [#302](https://github.com/platanus/potassium/pull/302)

--- a/lib/potassium/assets/redis.yml
+++ b/lib/potassium/assets/redis.yml
@@ -1,6 +1,5 @@
 development: &default
-  host: <%= ENV["BOXEN_REDIS_HOST"] || ENV["REDIS_HOST"] || "127.0.0.1" %>
-  port: <%= ENV["BOXEN_REDIS_PORT"] || ENV["REDIS_PORT"] || 6379 %>
+  url: <%= ENV.fetch("REDIS_URL") %>
 
 test:
   <<: *default


### PR DESCRIPTION
Adds the necessary configuration to docker-compose.yml and the corresponding env vars.

Also changes the `redis.yml` config file to force the definition of the `REDIS_URL` env var in development in an effort to make it more consistent with production.

closes #328 