### PR TITLE
Feat/ Beta support for graphql

### DIFF
--- a/lib/potassium/assets/README.yml
+++ b/lib/potassium/assets/README.yml
@@ -133,6 +133,9 @@ readme:
         power_api:
           title: "API Support"
           body: "This projects uses [Power API](https://github.com/platanus/power_api). It's a Rails engine that gathers a set of gems and configurations designed to build incredible REST APIs."
+        graphql:
+          title: "API Support"
+          body: "This projects uses [graphql-ruby](https://graphql-ruby.org/) to generate a GraphQL API."
         active_admin:
           title: "Administration"
           body: |

--- a/lib/potassium/assets/app/graphql/graphql_controller.rb
+++ b/lib/potassium/assets/app/graphql/graphql_controller.rb
@@ -1,0 +1,55 @@
+class GraphqlController < ApplicationController
+  # If accessing from outside this domain, nullify the session
+  # This allows for outside API access while preventing CSRF attacks,
+  # but you'll have to authenticate your user separately
+  # protect_from_forgery with: :null_session
+
+  def execute
+    variables = prepare_variables(params[:variables])
+    query = params[:query]
+    operation_name = params[:operationName]
+    context = { current_user: get_current_user }
+    result = GqlTestSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
+    render json: result
+  rescue => e
+    raise e unless Rails.env.development?
+    handle_error_in_development e
+  end
+
+  private
+
+  # Handle variables in form data, JSON body, or a blank value
+  def prepare_variables(variables_param)
+    case variables_param
+    when String
+      if variables_param.present?
+        JSON.parse(variables_param) || {}
+      else
+        {}
+      end
+    when Hash
+      variables_param
+    when ActionController::Parameters
+      variables_param.to_unsafe_hash # GraphQL-Ruby will validate name and type of incoming variables.
+    when nil
+      {}
+    else
+      raise ArgumentError, "Unexpected parameter: #{variables_param}"
+    end
+  end
+
+  def handle_error_in_development(e)
+    logger.error e.message
+    logger.error e.backtrace.join("\n")
+
+    render json: { errors: [{ message: e.message, backtrace: e.backtrace }], data: {} }, status: 500
+  end
+
+  def get_current_user
+    if request.headers['Authorization']
+      _, token = request.headers['Authorization'].split
+      decoded_token = JWT.decode token, ENV['HMAC_SECRET'], true, { algorithm: 'HS256' }
+      User.find(decoded_token.first["id"])
+    end
+  end
+end

--- a/lib/potassium/assets/app/graphql/graphql_controller.rb
+++ b/lib/potassium/assets/app/graphql/graphql_controller.rb
@@ -9,7 +9,7 @@ class GraphqlController < ApplicationController
     query = params[:query]
     operation_name = params[:operationName]
     context = { current_user: get_current_user }
-    result = GqlTestSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
+    result = GqlSampleSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
   rescue => e
     raise e unless Rails.env.development?

--- a/lib/potassium/assets/app/graphql/mutations/login_mutation.rb
+++ b/lib/potassium/assets/app/graphql/mutations/login_mutation.rb
@@ -1,0 +1,24 @@
+require 'jwt'
+
+class Mutations::LoginMutation < Mutations::BaseMutation
+  null true
+
+  # argument :user_id, ID, required: true, loads: Types::UserType
+  argument :email, String, required: true
+  argument :password, String, required: true
+
+
+  field :token, String, null: true
+
+  def resolve(email:, password:)
+    user = User.find_by(email: email)
+    if user&.valid_password?(password)
+      payload = { id: user.id, email: user.email, exp: (Time.zone.now + 24.hours).to_i }
+      token = JWT.encode payload, ENV['HMAC_SECRET'], 'HS256'
+      return { token: token }
+    end
+    GraphQL::ExecutionError.new("User or Password invalid")
+  rescue ActiveRecord::RecordInvalid => e
+    GraphQL::ExecutionError.new("Invalid input: #{e.record.errors.full_messages.join(', ')}")
+  end
+end

--- a/lib/potassium/assets/app/graphql/mutations/login_mutation.rb
+++ b/lib/potassium/assets/app/graphql/mutations/login_mutation.rb
@@ -3,7 +3,6 @@ require 'jwt'
 class Mutations::LoginMutation < Mutations::BaseMutation
   null true
 
-  # argument :user_id, ID, required: true, loads: Types::UserType
   argument :email, String, required: true
   argument :password, String, required: true
 

--- a/lib/potassium/assets/app/graphql/queries/base_query.rb
+++ b/lib/potassium/assets/app/graphql/queries/base_query.rb
@@ -1,0 +1,4 @@
+module Queries
+  class BaseQuery < GraphQL::Schema::Resolver
+  end
+end

--- a/lib/potassium/assets/app/graphql/types/base/base_argument.rb
+++ b/lib/potassium/assets/app/graphql/types/base/base_argument.rb
@@ -1,0 +1,4 @@
+module Types::Base
+  class BaseArgument < GraphQL::Schema::Argument
+  end
+end

--- a/lib/potassium/assets/app/graphql/types/base/base_enum.rb
+++ b/lib/potassium/assets/app/graphql/types/base/base_enum.rb
@@ -1,0 +1,4 @@
+module Types::Base
+  class BaseEnum < GraphQL::Schema::Enum
+  end
+end

--- a/lib/potassium/assets/app/graphql/types/base/base_field.rb
+++ b/lib/potassium/assets/app/graphql/types/base/base_field.rb
@@ -1,0 +1,5 @@
+module Types::Base
+  class BaseField < GraphQL::Schema::Field
+    argument_class Types::Base::BaseArgument
+  end
+end

--- a/lib/potassium/assets/app/graphql/types/base/base_input_object.rb
+++ b/lib/potassium/assets/app/graphql/types/base/base_input_object.rb
@@ -1,0 +1,5 @@
+module Types::Base
+  class BaseInputObject < GraphQL::Schema::InputObject
+    argument_class Types::Base::BaseArgument
+  end
+end

--- a/lib/potassium/assets/app/graphql/types/base/base_interface.rb
+++ b/lib/potassium/assets/app/graphql/types/base/base_interface.rb
@@ -1,0 +1,7 @@
+module Types::Base
+  module BaseInterface
+    include GraphQL::Schema::Interface
+
+    field_class Types::Base::BaseField
+  end
+end

--- a/lib/potassium/assets/app/graphql/types/base/base_object.rb
+++ b/lib/potassium/assets/app/graphql/types/base/base_object.rb
@@ -1,0 +1,5 @@
+module Types::Base
+  class BaseObject < GraphQL::Schema::Object
+    field_class Types::Base::BaseField
+  end
+end

--- a/lib/potassium/assets/app/graphql/types/base/base_scalar.rb
+++ b/lib/potassium/assets/app/graphql/types/base/base_scalar.rb
@@ -1,0 +1,4 @@
+module Types::Base
+  class BaseScalar < GraphQL::Schema::Scalar
+  end
+end

--- a/lib/potassium/assets/app/graphql/types/base/base_union.rb
+++ b/lib/potassium/assets/app/graphql/types/base/base_union.rb
@@ -1,0 +1,4 @@
+module Types::Base
+  class BaseUnion < GraphQL::Schema::Union
+  end
+end

--- a/lib/potassium/assets/app/graphql/types/mutation_type.rb
+++ b/lib/potassium/assets/app/graphql/types/mutation_type.rb
@@ -1,0 +1,10 @@
+module Types
+  class MutationType < Types::Base::BaseObject
+    # TODO: remove me
+    field :test_field, String, null: false,
+      description: "An example field added by the generator"
+    def test_field
+      "Hello World"
+    end
+  end
+end

--- a/lib/potassium/assets/app/graphql/types/query_type.rb
+++ b/lib/potassium/assets/app/graphql/types/query_type.rb
@@ -1,0 +1,13 @@
+module Types
+  class QueryType < Types::Base::BaseObject
+    # Add root-level fields here.
+    # They will be entry points for queries on your schema.
+
+    # TODO: remove me
+    field :test_field, String, null: false,
+      description: "An example field added by the generator"
+    def test_field
+      "Hello World!"
+    end
+  end
+end

--- a/lib/potassium/assets/config/graphql_playground.rb
+++ b/lib/potassium/assets/config/graphql_playground.rb
@@ -1,18 +1,20 @@
 # config/initializers/graphql_playground.rb
 # All config options have a default that should work out of the box
-GraphqlPlayground::Rails.configure do |config|
-  # config.headers = {
-  #   'X-Auth-Header' => ->(view_context) { "123" }
-  # }
-  # config.title = "Playground"
-  # config.csrf = true
-  # config.playground_version = "latest"
-  # # Ideally the assets would be added to your projects `vendor/assets` directories
-  # config.favicon = "/assets/playground.ico"
-  # config.playground_js_url = "/assets/playground.js"
-  # config.playground_css_url = "/assets/playground.css"
-  # # see: https://github.com/prisma-labs/graphql-playground#settings
-  config.settings = {
-    "schema.polling.enable": false
-  }
+if Rails.env.development?
+  GraphqlPlayground::Rails.configure do |config|
+    # config.headers = {
+    #   'X-Auth-Header' => ->(view_context) { "123" }
+    # }
+    # config.title = "Playground"
+    # config.csrf = true
+    # config.playground_version = "latest"
+    # # Ideally the assets would be added to your projects `vendor/assets` directories
+    # config.favicon = "/assets/playground.ico"
+    # config.playground_js_url = "/assets/playground.js"
+    # config.playground_css_url = "/assets/playground.css"
+    # # see: https://github.com/prisma-labs/graphql-playground#settings
+    config.settings = {
+      "schema.polling.enable": false
+    }
+  end
 end

--- a/lib/potassium/assets/config/graphql_playground.rb
+++ b/lib/potassium/assets/config/graphql_playground.rb
@@ -1,18 +1,18 @@
 # config/initializers/graphql_playground.rb
-# All config options have a default that sould work out of the box
+# All config options have a default that should work out of the box
 GraphqlPlayground::Rails.configure do |config|
-    # config.headers = {
-    #   'X-Auth-Header' => ->(view_context) { "123" }
-    # }
-    # config.title = "Playground"
-    # config.csrf = true
-    # config.playground_version = "latest"
-    # # Ideally the assets would be added to your projects `vendor/assets` directories
-    # config.favicon = "/assets/playground.ico"
-    # config.playground_js_url = "/assets/playground.js"
-    # config.playground_css_url = "/assets/playground.css"
-    # # see: https://github.com/prisma-labs/graphql-playground#settings
-    config.settings = {
-      "schema.polling.enable": false
-    }
-  end
+  # config.headers = {
+  #   'X-Auth-Header' => ->(view_context) { "123" }
+  # }
+  # config.title = "Playground"
+  # config.csrf = true
+  # config.playground_version = "latest"
+  # # Ideally the assets would be added to your projects `vendor/assets` directories
+  # config.favicon = "/assets/playground.ico"
+  # config.playground_js_url = "/assets/playground.js"
+  # config.playground_css_url = "/assets/playground.css"
+  # # see: https://github.com/prisma-labs/graphql-playground#settings
+  config.settings = {
+    "schema.polling.enable": false
+  }
+end

--- a/lib/potassium/assets/config/graphql_playground.rb
+++ b/lib/potassium/assets/config/graphql_playground.rb
@@ -1,0 +1,18 @@
+# config/initializers/graphql_playground.rb
+# All config options have a default that sould work out of the box
+GraphqlPlayground::Rails.configure do |config|
+    # config.headers = {
+    #   'X-Auth-Header' => ->(view_context) { "123" }
+    # }
+    # config.title = "Playground"
+    # config.csrf = true
+    # config.playground_version = "latest"
+    # # Ideally the assets would be added to your projects `vendor/assets` directories
+    # config.favicon = "/assets/playground.ico"
+    # config.playground_js_url = "/assets/playground.js"
+    # config.playground_css_url = "/assets/playground.css"
+    # # see: https://github.com/prisma-labs/graphql-playground#settings
+    config.settings = {
+      "schema.polling.enable": false
+    }
+  end

--- a/lib/potassium/cli_options.rb
+++ b/lib/potassium/cli_options.rb
@@ -75,12 +75,10 @@ module Potassium::CliOptions # rubocop:disable Metrics/ModuleLength
       default_test_value: false
     },
     {
-      type: :switch,
+      type: :flag,
       name: "api",
-      desc: "Whether to apply the API mode or not",
-      negatable: true,
-      default_value: "none",
-      default_test_value: false
+      desc: "Which API interface to use",
+      default_value: "none"
     },
     {
       type: :flag,

--- a/lib/potassium/cli_options.rb
+++ b/lib/potassium/cli_options.rb
@@ -78,7 +78,8 @@ module Potassium::CliOptions # rubocop:disable Metrics/ModuleLength
       type: :flag,
       name: "api",
       desc: "Which API interface to use",
-      default_value: "none"
+      default_value: "none",
+      default_test_value: "None"
     },
     {
       type: :flag,

--- a/lib/potassium/recipes/api.rb
+++ b/lib/potassium/recipes/api.rb
@@ -25,7 +25,7 @@ class Recipes::Api < Rails::AppBuilder
   end
 
   def installed?
-    gem_exists?(/power_api/)
+    gem_exists?(/power_api/) || gem_exists?(/graphql/)
   end
 
   private
@@ -49,7 +49,7 @@ class Recipes::Api < Rails::AppBuilder
     if get(:authentication)
       gather_gem 'jwt'
     end
-    gather_gems(:development) do
+    gather_gems(:development, :test) do
       gather_gem 'graphql_playground-rails'
     end
 

--- a/lib/potassium/recipes/api.rb
+++ b/lib/potassium/recipes/api.rb
@@ -69,6 +69,7 @@ class Recipes::Api < Rails::AppBuilder
       remove_dir 'app/graphql/types'
       directory '../assets/app/graphql/types', 'app/graphql/types'
       gsub_file 'app/graphql/mutations/base_mutation.rb', 'Types::Base', 'Types::Base::'
+      directory '../assets/app/graphql/queries', 'app/graphql/queries'
     end
   end
 end

--- a/lib/potassium/recipes/api.rb
+++ b/lib/potassium/recipes/api.rb
@@ -96,6 +96,12 @@ class Recipes::Api < Rails::AppBuilder
           after: 'class MutationType < Types::Base::BaseObject'
         )
       end
+
+      inject_into_file(
+        'app/controllers/graphql_controller.rb',
+        "\n\n  skip_before_action :verify_authenticity_token",
+        after: '# protect_from_forgery with: :null_session'
+      )
     end
   end
 end

--- a/lib/potassium/recipes/api.rb
+++ b/lib/potassium/recipes/api.rb
@@ -107,6 +107,8 @@ class Recipes::Api < Rails::AppBuilder
         "\n\n  skip_before_action :verify_authenticity_token",
         after: '# protect_from_forgery with: :null_session'
       )
+
+      add_readme_section :internal_dependencies, :graphql
     end
   end
 end

--- a/lib/potassium/recipes/api.rb
+++ b/lib/potassium/recipes/api.rb
@@ -100,6 +100,7 @@ class Recipes::Api < Rails::AppBuilder
           "\n    field :login, mutation: Mutations::LoginMutation",
           after: 'class MutationType < Types::Base::BaseObject'
         )
+        append_to_file(".env.development", "HMAC_SECRET=\n")
       end
 
       inject_into_file(

--- a/lib/potassium/recipes/api.rb
+++ b/lib/potassium/recipes/api.rb
@@ -46,6 +46,9 @@ class Recipes::Api < Rails::AppBuilder
 
   def add_graphql
     gather_gem 'graphql'
+    if get(:authentication)
+      gather_gem 'jwt'
+    end
     gather_gems(:development) do
       gather_gem 'graphql_playground-rails'
     end
@@ -72,6 +75,22 @@ class Recipes::Api < Rails::AppBuilder
       directory '../assets/app/graphql/queries', 'app/graphql/queries'
       gsub_file 'app/graphql/mutations/base_mutation.rb', 'RelayClassic', ''
       gsub_file 'app/graphql/mutations/base_mutation.rb', '    input_object_class Types::Base::InputObject\n', ''
+
+      if get(:authentication)
+        copy_file(
+          '../assets/app/graphql/graphql_controller.rb',
+          'app/controllers/graphql_controller.rb',
+          force: true
+        )
+        copy_file(
+          '../assets/app/graphql/mutations/login_mutation.rb',
+          'app/graphql/mutations/login_mutation.rb'
+        )
+        inject_into_file('app/graphql/types/mutation_type.rb',
+          "\n    field :login, mutation: Mutations::LoginMutation",
+          after: 'class MutationType < Types::Base::BaseObject'
+        )
+      end
     end
   end
 end

--- a/lib/potassium/recipes/api.rb
+++ b/lib/potassium/recipes/api.rb
@@ -70,6 +70,8 @@ class Recipes::Api < Rails::AppBuilder
       directory '../assets/app/graphql/types', 'app/graphql/types'
       gsub_file 'app/graphql/mutations/base_mutation.rb', 'Types::Base', 'Types::Base::'
       directory '../assets/app/graphql/queries', 'app/graphql/queries'
+      gsub_file 'app/graphql/mutations/base_mutation.rb', 'RelayClassic', ''
+      gsub_file 'app/graphql/mutations/base_mutation.rb', '    input_object_class Types::Base::InputObject\n', ''
     end
   end
 end

--- a/lib/potassium/recipes/api.rb
+++ b/lib/potassium/recipes/api.rb
@@ -71,16 +71,21 @@ class Recipes::Api < Rails::AppBuilder
       )
       remove_dir 'app/graphql/types'
       directory '../assets/app/graphql/types', 'app/graphql/types'
-      gsub_file 'app/graphql/mutations/base_mutation.rb', 'Types::Base', 'Types::Base::'
+      gsub_file 'app/graphql/mutations/base_mutation.rb', 'Types::Base', 'Types::Base::Base'
       directory '../assets/app/graphql/queries', 'app/graphql/queries'
       gsub_file 'app/graphql/mutations/base_mutation.rb', 'RelayClassic', ''
-      gsub_file 'app/graphql/mutations/base_mutation.rb', '    input_object_class Types::Base::InputObject\n', ''
+      gsub_file 'app/graphql/mutations/base_mutation.rb', "    input_object_class Types::Base::BaseInputObject\n", ''
 
       if get(:authentication)
         copy_file(
           '../assets/app/graphql/graphql_controller.rb',
           'app/controllers/graphql_controller.rb',
           force: true
+        )
+        gsub_file(
+          'app/controllers/graphql_controller.rb',
+          'GqlSampleSchema',
+          "#{get(:titleized_app_name).delete(' ')}Schema"
         )
         copy_file(
           '../assets/app/graphql/mutations/login_mutation.rb',

--- a/lib/potassium/recipes/api.rb
+++ b/lib/potassium/recipes/api.rb
@@ -62,6 +62,13 @@ class Recipes::Api < Rails::AppBuilder
         playground_route,
         after: 'post "/graphql", to: "graphql#execute"'
       )
+      copy_file(
+        "../assets/config/graphql_playground.rb",
+        "config/initializers/graphql_playground.rb"
+      )
+      remove_dir 'app/graphql/types'
+      directory '../assets/app/graphql/types', 'app/graphql/types'
+      gsub_file 'app/graphql/mutations/base_mutation.rb', 'Types::Base', 'Types::Base::'
     end
   end
 end

--- a/lib/potassium/recipes/api.rb
+++ b/lib/potassium/recipes/api.rb
@@ -61,7 +61,8 @@ class Recipes::Api < Rails::AppBuilder
           mount GraphqlPlayground::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
         end
       HEREDOC
-      inject_into_file('config/routes.rb',
+      inject_into_file(
+        'config/routes.rb',
         playground_route,
         after: 'post "/graphql", to: "graphql#execute"'
       )
@@ -74,7 +75,10 @@ class Recipes::Api < Rails::AppBuilder
       gsub_file 'app/graphql/mutations/base_mutation.rb', 'Types::Base', 'Types::Base::Base'
       directory '../assets/app/graphql/queries', 'app/graphql/queries'
       gsub_file 'app/graphql/mutations/base_mutation.rb', 'RelayClassic', ''
-      gsub_file 'app/graphql/mutations/base_mutation.rb', "    input_object_class Types::Base::BaseInputObject\n", ''
+      gsub_file(
+        'app/graphql/mutations/base_mutation.rb',
+        "    input_object_class Types::Base::BaseInputObject\n", ''
+      )
 
       if get(:authentication)
         copy_file(
@@ -91,7 +95,8 @@ class Recipes::Api < Rails::AppBuilder
           '../assets/app/graphql/mutations/login_mutation.rb',
           'app/graphql/mutations/login_mutation.rb'
         )
-        inject_into_file('app/graphql/types/mutation_type.rb',
+        inject_into_file(
+          'app/graphql/types/mutation_type.rb',
           "\n    field :login, mutation: Mutations::LoginMutation",
           after: 'class MutationType < Types::Base::BaseObject'
         )

--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -88,35 +88,12 @@ class Recipes::FrontEnd < Rails::AppBuilder
 
   def setup_apollo
     run 'bin/yarn add vue-apollo graphql apollo-client apollo-link apollo-link-http apollo-cache-inmemory graphql-tag'
-    apollo_imports = <<~HEREDOC
-    \n
-    import { ApolloClient } from 'apollo-client';
-    import { createHttpLink } from 'apollo-link-http';
-    import { InMemoryCache } from 'apollo-cache-inmemory';
-    import VueApollo from 'vue-apollo';
-    HEREDOC
+
     inject_into_file(
       'app/javascript/packs/application.js',
       apollo_imports,
       after: "import App from '../app.vue';"
     )
-
-    apollo_loading = <<~HEREDOC
-    \n
-    const httpLink = createHttpLink({
-      uri: `${window.location.origin}/graphql`,
-    })
-    const cache = new InMemoryCache()
-    const apolloClient = new ApolloClient({
-      link: httpLink,
-      cache,
-    })
-
-    Vue.use(VueApollo)
-    const apolloProvider = new VueApollo({
-      defaultClient: apolloClient,
-    })
-    HEREDOC
 
     inject_into_file(
       'app/javascript/packs/application.js',
@@ -139,6 +116,35 @@ class Recipes::FrontEnd < Rails::AppBuilder
       none: nil
     }
     frameworks[framework]
+  end
+
+  def apollo_imports
+    <<~JS
+      \n
+      import { ApolloClient } from 'apollo-client';
+      import { createHttpLink } from 'apollo-link-http';
+      import { InMemoryCache } from 'apollo-cache-inmemory';
+      import VueApollo from 'vue-apollo';
+    JS
+  end
+
+  def apollo_loading
+    <<~JS
+      \n
+      const httpLink = createHttpLink({
+        uri: `${window.location.origin}/graphql`,
+      })
+      const cache = new InMemoryCache()
+      const apolloClient = new ApolloClient({
+        link: httpLink,
+        cache,
+      })
+
+      Vue.use(VueApollo)
+      const apolloProvider = new VueApollo({
+        defaultClient: apolloClient,
+      })
+    JS
   end
 
   def setup_client_css

--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -104,7 +104,7 @@ class Recipes::FrontEnd < Rails::AppBuilder
     apollo_loading = <<~HEREDOC
     \n
     const httpLink = createHttpLink({
-      uri: 'http://localhost:3000/graphql',
+      uri: `${window.location.origin}/graphql`,
     })
     const cache = new InMemoryCache()
     const apolloClient = new ApolloClient({

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Api" do
   before :all do
     drop_dummy_database
     remove_project_directory
-    create_dummy_project("api" => true)
+    create_dummy_project("api" => :rest)
   end
 
   it "adds power_api related gems to Gemfile" do

--- a/spec/features/front_end_spec.rb
+++ b/spec/features/front_end_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe "Front end" do
       )
       expect(tailwind_config_file).to include('module.exports')
     end
+
+    context "with graphql" do
+      before(:all) do
+        remove_project_directory
+        create_dummy_project("front_end" => "vue", "api" => "graphql")
+      end
+
+      it "creates a vue project with apollo" do
+        expect(node_modules_file).to include("\"vue-apollo\"")
+        expect(application_js_file).to include("import { ApolloClient } from 'apollo-client';")
+        expect(application_js_file).to include("Vue.use(VueApollo)")
+        expect(application_js_file).to include("apolloProvider,")
+      end
+    end
   end
 
   context "with angular" do

--- a/spec/features/graphql_spec.rb
+++ b/spec/features/graphql_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+
+RSpec.describe "Api" do
+
+  context 'when using only graphql' do
+    before :all do
+      drop_dummy_database
+      remove_project_directory
+      create_dummy_project("api" => :graphql)
+    end
+
+    it "adds graphql related gems to Gemfile" do
+      gemfile_content = IO.read("#{project_path}/Gemfile")
+      expect(gemfile_content).to include("gem 'graphql'")
+      expect(gemfile_content).to include("gem 'graphql_playground-rails'")
+      expect(gemfile_content).not_to include("gem 'graphiql'")
+    end
+
+    it 'installs and sets up graphql' do
+      schema = IO.read("#{project_path}/app/graphql/#{PotassiumTestHelpers::APP_NAME.dasherize.gsub('-','_')}_schema.rb")
+      expect(schema).to include("class #{PotassiumTestHelpers::APP_NAME.titleize.delete(' ')}Schema < GraphQL::Schema")
+
+      base_mutation = IO.read("#{project_path}/app/graphql/mutations/base_mutation.rb")
+      expect(base_mutation).to include('Types::Base::Base')
+      expect(base_mutation).not_to include('input_object_class')
+      expect(base_mutation).not_to include('RelayClassic')
+
+      controller = base_mutation = IO.read("#{project_path}/app/controllers/graphql_controller.rb")
+      expect(controller).to include('skip_before_action :verify_authenticity_token')
+    end
+
+    it 'sets up graphql playground' do
+      routes = IO.read("#{project_path}/config/routes.rb")
+      expect(routes).to include('mount GraphqlPlayground::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"')
+      config = IO.read("#{project_path}/config/initializers/graphql_playground.rb")
+      expect(config).to include('GraphqlPlayground::Rails.configure do |config|')
+    end
+  end
+
+  context 'when using authentication' do
+    before :all do
+      drop_dummy_database
+      remove_project_directory
+      create_dummy_project("api" => :graphql, "devise": true)
+    end
+
+    it 'gathers jwt gem' do
+      gemfile_content = IO.read("#{project_path}/Gemfile")
+      expect(gemfile_content).to include("gem 'jwt'")
+    end
+
+    it 'Adds auth related mutation and controller' do
+      controller = base_mutation = IO.read("#{project_path}/app/controllers/graphql_controller.rb")
+      expect(controller).to include('get_current_user')
+      expect(controller).to include("#{PotassiumTestHelpers::APP_NAME.titleize.delete(' ')}Schema.execute")
+
+      mutation_type = IO.read("#{project_path}/app/graphql/types/mutation_type.rb")
+      expect(mutation_type).to include('field :login, mutation: Mutations::LoginMutation')
+
+      login_mutation = IO.read("#{project_path}/app/graphql/mutations/login_mutation.rb")
+      expect(login_mutation).to include('class Mutations::LoginMutation < Mutations::BaseMutation')
+    end
+  end
+
+end

--- a/spec/features/graphql_spec.rb
+++ b/spec/features/graphql_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
-RSpec.describe "Api" do
-
+RSpec.describe "GraphQL" do
   context 'when using only graphql' do
     before :all do
       drop_dummy_database
@@ -17,21 +16,27 @@ RSpec.describe "Api" do
     end
 
     it 'installs and sets up graphql' do
-      schema = IO.read("#{project_path}/app/graphql/#{PotassiumTestHelpers::APP_NAME.dasherize.gsub('-','_')}_schema.rb")
-      expect(schema).to include("class #{PotassiumTestHelpers::APP_NAME.titleize.delete(' ')}Schema < GraphQL::Schema")
+      schema = IO.read(
+        "#{project_path}/app/graphql/#{PotassiumTestHelpers::APP_NAME.dasherize.tr('-', '_')}_schema.rb"
+      )
+      expect(schema).to include(
+        "class #{PotassiumTestHelpers::APP_NAME.titleize.delete(' ')}Schema < GraphQL::Schema"
+      )
 
       base_mutation = IO.read("#{project_path}/app/graphql/mutations/base_mutation.rb")
       expect(base_mutation).to include('Types::Base::Base')
       expect(base_mutation).not_to include('input_object_class')
       expect(base_mutation).not_to include('RelayClassic')
 
-      controller = base_mutation = IO.read("#{project_path}/app/controllers/graphql_controller.rb")
+      controller = IO.read("#{project_path}/app/controllers/graphql_controller.rb")
       expect(controller).to include('skip_before_action :verify_authenticity_token')
     end
 
     it 'sets up graphql playground' do
       routes = IO.read("#{project_path}/config/routes.rb")
-      expect(routes).to include('mount GraphqlPlayground::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"')
+      expect(routes).to include(
+        'mount GraphqlPlayground::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"'
+      )
       config = IO.read("#{project_path}/config/initializers/graphql_playground.rb")
       expect(config).to include('GraphqlPlayground::Rails.configure do |config|')
     end
@@ -50,9 +55,11 @@ RSpec.describe "Api" do
     end
 
     it 'Adds auth related mutation and controller' do
-      controller = base_mutation = IO.read("#{project_path}/app/controllers/graphql_controller.rb")
+      controller = IO.read("#{project_path}/app/controllers/graphql_controller.rb")
       expect(controller).to include('get_current_user')
-      expect(controller).to include("#{PotassiumTestHelpers::APP_NAME.titleize.delete(' ')}Schema.execute")
+      expect(controller).to include(
+        "#{PotassiumTestHelpers::APP_NAME.titleize.delete(' ')}Schema.execute"
+      )
 
       mutation_type = IO.read("#{project_path}/app/graphql/types/mutation_type.rb")
       expect(mutation_type).to include('field :login, mutation: Mutations::LoginMutation')
@@ -61,5 +68,4 @@ RSpec.describe "Api" do
       expect(login_mutation).to include('class Mutations::LoginMutation < Mutations::BaseMutation')
     end
   end
-
 end


### PR DESCRIPTION
Se agrega la opción de tener una API GraphQL a la receta de api. Esto implica principalmente el uso de la gema [graphql](https://graphql-ruby.org/) y la generación de la estructura del proyecto gql en la carpeta `graphql`. Además se usa la gema [graphql-playground](https://github.com/papodaca/graphql_playground-rails) para generar la documentación automática con el ambiente de prueba de las consultas. También se incluye la instalación y configuración de [vue-apollo](https://apollo.vuejs.org/) para el frontend. Gran parte esta basado en lo que hizo @GabrielLyonB  en su repo de prueba para la presentación de hace un par de meses.

En teoría este PR es lo mínimo suficiente para generar una App Vue+backend-GraphQL-rails en la que se puede empezar a desarrollar inmediatamente.

## Decisiones de diseño que revisar.

### Estructura de la carpeta GraphQL
La instalación por defecto de la gema `graphql` tiene hartas cosas que no me gustaron mucho y que no calzan mucho con la forma platanus de hacer las cosas lo más modularizado / desacoplado posible, por lo que la receta de potassium hace hartos cambios posteriores a correr la instalación. Suponiendo un modelo `Books`, un proyecto sería algo así:
```
graphql
|--mutations
   |  base_mutation.rb
   |--books_mutations
      |  create_book.rb
      |  delete_book.rb
|--queries
   |  base_query
   |--books_queries
      |  book.rb
      |  books.rb
|--types
   |  mutation_type.rb
   |  query_type.rb
   |--base
      |  base_argument.rb
      |  ...
|  sample_app_schema.rb
```
Los cambios que hice son mover los `base_types` a una carpeta `base` dentro de `types` y hacer una carpeta `queries`
que permite hacer un archivo por cada query mediante `resolvers` (la única otra opción es achoclonar todo el código dentro de `query_type.rb`) , me basé en este [tutorial de acá ](https://selleo.com/blog/graphql-with-ruby-on-rails-queries-in-multiple-files).

## Autenticación
Se implementó la autenticación mediante  un JWT  en un header. Si el usuario pidió devise en la receta entonces se autogenera todo el código para hacer login mediante una mutation y para detectar el current user mediante el token. 
Usé JWT porque así lo hizo @GabrielLyonB  en el repo de graphql anterior que tenía y no quise complicarme la vida haciendo otra cosa. Funciona revisando el jwt en el `graphql_controller.rb` y pasando el `current_user` dentro del `context` a query/mutation. Creo que sería mejor que quedara  algo similar pero con una herramienta más típica de nosotros como `simple_token_authentication` o la cookie de device y sin que quede todo el código acoplado en el controller.

## Uso de argumentos planos
Por default la gema genera que al hacer una mutation los argumentos se tengan que pasar como un `inputObject` en vez de como argumentos planos. Es decir una mutation se haría así
```gql
mutation{
  createBook(input:{author: 'un tipo', title:'un libro'}){
  }
}
```
En vez de:
```gql
mutation{
  createBook(author: 'un tipo', title:'un libro'){
  }
}
```
Sentí que solo agregaba ruido por lo que metí mano para que quedara como  la segunda opción, siguiendo lo que dicen [acá](https://github.com/rmosolgo/graphql-ruby/issues/2794)

## Ejemplo de uso.
Dado un modelo `book.rb` con campos `author` y `title`, definimos un type Book
```ruby
#graphql/types/book_type.rb
module Types::ModelTypes
  class BookType < Types::Base::BaseObject
    field :id, ID, null: false, description: 'identifier'
    field :author, String, null: false
    field :title, String, null: true
  end
end
```
Y una mutation para crear un libro
```ruby
#graphql/mutations/book_mutations/create_book_mutation.rb

module Mutations::PostMutations
  class CreatePostMutation < Mutations::BaseMutation
    null true

    argument :author, String, required: true
    argument :title, String, required: true

    def resolve(user_id:, title:, content:)
      book = Book.create!(author: author, title: title)
      { book: book }
    end
  end
end
```
Junto con la declaración en mutation_type.rb (similar a definir una ruta en routes.rb)
```ruby
#graphql/types/mutation_type.rb

module Types
  class MutationType < Types::Base::BaseObject
    field :create_book, mutation: Mutations::BookMutations::CreateBookMutation
  end
end
```

También definimos una query para acceder a un libro y la agregamos a `query_type.rb`

```ruby
#graphql/queries/book_queries/book.rb

module Queries::CommentQueries
  class Comments < Queries::BaseQuery
    type [Types::ModelTypes::BookType], null: false
    description "Returns a Book"

    argument :id, ID, required: true

    def resolve(id:)
      Book.find(id)
    end
  end
end

#graphql/types/query_type.rb

module Types
  class QueryType < Types::Base::BaseObject
    field :book, resolver: Queries::BookQueries::Book
  end
end

```

Gracias a apollo podemos definir en vue un componente que se conecte directamente con el backend mediante una query que es a la vez cacheada por apollo (El estado de la app se maneja mediante apollo, sin Vuex). 

```vue
#javascript/src/components/book.vue

<template>
  <div>
  {{book.author}}:  {{book.title}}
  </div>
</template>

<script>
import gql from "graphql-tag";
export default {
  props: {
   id: { type: String, required: true}
  },
  apollo: {
    book: {
      query: gql`query getBook($id: String!) {
        Book(id: $id) { 
          author
          title
        }
      }`,
      variables() {
        return {
          id: this.id
        }
      }
    }
  }
}
</script>
```

## Cosas pendientes

*  La autorización todavía no tengo claro como va a funcionar. La gema en versión pagada tiene una integración con pundit, pero no creo que hayan problemas para integrarlo nosotros a mano.
*  Respecto a como testear las queries y las mutations, aún no lo he probado pero viendo tutoriales se ve bien similar a como testeamos controllers en una api rest.

Nota: no me funcionó el linter en local y no me esforcé  en arreglarlo jaja así que el mono se enojó :roll_eyes: 