### PR TITLE
fix(ci-config): change cache path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,8 @@ env-vars: &env-vars
   BUNDLE_JOBS: 4
   RAILS_ENV: test
   RAKE_ENV: test
+  BUNDLE_PATH: /home/circleci/project/vendor/bundle
+  GEM_PATH: /home/circleci/project/vendor/bundle/ruby/2.7.0
 
 executors:
   ruby-executor:
@@ -20,9 +22,9 @@ commands:
 
       - restore_cache:
           keys:
-          - potassium-bundle-{{ .Branch }}
-          - potassium-bundle-master
-          - potassium-bundle
+          - potassium-vendor-bundle-{{ .Branch }}
+          - potassium-vendor-bundle-master
+          - potassium-vendor-bundle
 
       - run:
           name: Install bundle dependencies
@@ -31,9 +33,9 @@ commands:
             bundle _2.1.4_ install
 
       - save_cache:
-          key: potassium-bundle-{{ .Branch }}
+          key: potassium-vendor-bundle-{{ .Branch }}
           paths:
-            - /usr/local/bundle
+            - vendor/bundle
 
 jobs:
   test:


### PR DESCRIPTION
### Problem
I broke cache restore in #335 😅 . The problem was that path `/usr/local/bundle` couldn't be written to, so restore cache failed and the job stoped.

### Solution
This PR fixes it by changing bundle path. I was trying to use `vendor/bundle` but it had 2 problems:
- It's a relative path, so when in the tests `bin/potassium` is run inside of `tmp` folder it wasn't finding it -> fixed by using absolute path
- Bundle path was changed, but ruby still wasn't finding the gems. I tried setting `GEM_HOME` [like it was before](https://github.com/platanus/potassium/blob/6a932c36d83ca522fe32ea61eccd2c6a4897e7cb/.circleci/config.yml#L11), but it didn't work, not sure why -> fixed by setting `GEM_PATH`

Also, cache key was changed to avoid hits with previous flawed cache.

In [the latest build](https://app.circleci.com/pipelines/github/platanus/potassium/175/workflows/5c5ff133-a207-436b-8934-9766584ff755/jobs/976/steps) you can see that restore cache and tests were performed succesfully.