### PR TITLE
Remove delayed jobs remnants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Features:
   - Add Google Tag Manager [#326](https://github.com/platanus/potassium/pull/326)
   - Update rubocop and rubocop-rspec for potassium and generated projects [#337](https://github.com/platanus/potassium/pull/337)
 
+Fixes:
+  - Change `backgroud_processor` cli option to a switch. As of [#137](https://github.com/platanus/potassium/pull/137) we no longer have `delayed_jobs` as an option, it's only `sidekiq` now [#340](https://github.com/platanus/potassium/pull/340)
+
 ## 6.1.0
 
 Features:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ The following optional integrations are also added:
 - [ActiveAdmin](http://activeadmin.info) for admin interfaces
 - [ActiveAdminAddons](https://github.com/platanus/activeadmin_addons) for some help with ActiveAdmin
 - [Pundit](https://github.com/elabs/pundit) for role-based authorization
-- [DelayedJob](https://github.com/collectiveidea/delayed_job) to execute longer tasks in the background
 - [Sidekiq](https://github.com/mperham/sidekiq) a simple, efficient background processing for Ruby
 - [Sidekiq-scheduler](https://github.com/moove-it/sidekiq-scheduler) to run scheduled processes
 - Mailing configuration for [AWS SES](https://github.com/aws/aws-sdk-rails)

--- a/lib/potassium/assets/README.yml
+++ b/lib/potassium/assets/README.yml
@@ -112,9 +112,6 @@ readme:
         pundit:
           title: "Authorization"
           body: "For defining which parts of the system each user has access to, we have chosen to include the [Pundit](https://github.com/elabs/pundit) gem, by [Elabs](http://elabs.se/)."
-        delayed_job:
-          title: "Queue System"
-          body: "For managing tasks in the background, this project uses [DelayedJob](https://github.com/collectiveidea/delayed_job)"
         sidekiq:
           title: "Queue System"
           body: "For managing tasks in the background, this project uses [Sidekiq](https://github.com/mperham/sidekiq)"

--- a/lib/potassium/cli_options.rb
+++ b/lib/potassium/cli_options.rb
@@ -97,10 +97,10 @@ module Potassium::CliOptions # rubocop:disable Metrics/ModuleLength
       default_test_value: false
     },
     {
-      type: :flag,
+      type: :switch,
       name: "background_processor",
-      desc: "Decides which background processor to use. Available: sidekiq, delayed_job, none",
-      default_test_value: "None"
+      desc: "Whether to use Sidekiq for background processing or not",
+      default_test_value: false
     },
     {
       type: :switch,

--- a/spec/features/background_processor_spec.rb
+++ b/spec/features/background_processor_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "BackgroundProcessor" do
     before :all do
       drop_dummy_database
       remove_project_directory
-      create_dummy_project("background_processor" => "sidekiq", "heroku" => true)
+      create_dummy_project("background_processor" => true, "heroku" => true)
     end
 
     it "adds sidekiq gem to Gemfile" do


### PR DESCRIPTION
### Context

In #137 delayed jobs was removed as a background processor option, and the recipe was changed to a yes/no question to include sidekiq

### Changes
- Removes delayed jobs from used technologies section of potassium and generated projects readme
- Fixes the cli option, changing it to a switch