### PR TITLE
Validate names in heroku recipe do not exceed the name limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
 
 Fixes:
   - Change `backgroud_processor` cli option to a switch. As of [#137](https://github.com/platanus/potassium/pull/137) we no longer have `delayed_jobs` as an option, it's only `sidekiq` now [#340](https://github.com/platanus/potassium/pull/340)
+  - Update `heroku` recipe to check if an app or pipeline name is valid before creating it on Heroku [#344](https://github.com/platanus/potassium/pull/344)
 
 ## 6.1.0
 

--- a/lib/potassium/recipes/heroku.rb
+++ b/lib/potassium/recipes/heroku.rb
@@ -1,13 +1,7 @@
 class Recipes::Heroku < Rails::AppBuilder
   NAME_PREFIX = 'pl'
-
-  attr_accessor :app_name_staging
-
-  def initialize(args)
-    super(args)
-    set(:heroku_app_name_staging, app_name_for('staging'))
-    set(:heroku_app_name_production, app_name_for('production'))
-  end
+  ENVIRONMENTS = ['staging', 'production']
+  HEROKU_NAMES_MAX_CHARS = 30
 
   def ask
     heroku = answer(:heroku) do
@@ -16,6 +10,8 @@ class Recipes::Heroku < Rails::AppBuilder
 
     if heroku
       set(:heroku, heroku)
+
+      ENVIRONMENTS.each { |environment| set_app_name_for(environment) }
     end
   end
 
@@ -47,31 +43,34 @@ class Recipes::Heroku < Rails::AppBuilder
     template "../assets/bin/setup_heroku.erb", "bin/setup_heroku", force: true
     run "chmod a+x bin/setup_heroku"
 
-    if logged_in?
-      %w(staging production).each do |environment|
-        create_app_on_heroku(environment)
-      end
-      puts "Remember to connect the github repository to the new pipeline"
-      open_pipeline_command = "\e[33mheroku pipelines:open #{heroku_pipeline_name}\e[0m"
-      puts "run #{open_pipeline_command} to open the dashboard"
-    else
-      puts "You are not logged in into heroku"
-      login_command = "\e[33mheroku login\e[0m"
-      puts "Run #{login_command} and enter your credentials"
-      puts "You can install the heroku recipe again create the app in heroku"
-      install_command = "\e[33mpostassium install heroku --force\e[0m"
-      puts "Just run #{install_command}"
-    end
+    logged_in? ? create_apps : puts_not_logged_in_msg
 
     add_readme_header :deployment
   end
 
-  def heroku_pipeline_name
-    app_name.dasherize
+  def create_apps
+    ENVIRONMENTS.each { |environment| create_app_on_heroku(environment) }
+    puts "Remember to connect the github repository to the new pipeline"
+    open_pipeline_command = "\e[33mheroku pipelines:open #{heroku_pipeline_name}\e[0m"
+    puts "run #{open_pipeline_command} to open the dashboard"
   end
 
-  def app_name_for(environment)
-    "#{NAME_PREFIX}-#{app_name.dasherize}-#{environment}"
+  def puts_not_logged_in_msg
+    puts "You are not logged in into heroku"
+    login_command = "\e[33mheroku login\e[0m"
+    puts "Run #{login_command} and enter your credentials"
+    puts "You can install the heroku recipe again to create the app in heroku"
+    install_command = "\e[33mpostassium install heroku --force\e[0m"
+    puts "Just run #{install_command}"
+  end
+
+  def heroku_pipeline_name
+    @heroku_pipeline_name ||= valid_heroku_name(app_name.dasherize, 'pipeline')
+  end
+
+  def set_app_name_for(environment)
+    default_name = "#{NAME_PREFIX}-#{app_name.dasherize}-#{environment}"
+    set("heroku_app_name_#{environment}".to_sym, valid_heroku_name(default_name, environment))
   end
 
   def logged_in?
@@ -84,7 +83,7 @@ class Recipes::Heroku < Rails::AppBuilder
 
   def create_app_on_heroku(environment)
     rack_env = "RACK_ENV=production"
-    staged_app_name = app_name_for(environment)
+    staged_app_name = get("heroku_app_name_#{environment}".to_sym)
 
     run_toolbelt_command "create #{staged_app_name} --remote #{environment}"
     run_toolbelt_command "labs:enable runtime-dyno-metadata", staged_app_name
@@ -99,14 +98,14 @@ class Recipes::Heroku < Rails::AppBuilder
   def set_rails_secrets(environment)
     run_toolbelt_command(
       "config:add SECRET_KEY_BASE=#{generate_secret}",
-      app_name_for(environment)
+      get("heroku_app_name_#{environment}".to_sym)
     )
   end
 
   def set_app_multi_buildpack(environment)
     run_toolbelt_command(
       "buildpacks:set https://github.com/heroku/heroku-buildpack-multi.git",
-      app_name_for(environment)
+      get("heroku_app_name_#{environment}".to_sym)
     )
   end
 
@@ -132,5 +131,13 @@ class Recipes::Heroku < Rails::AppBuilder
     else
       `heroku #{command} --app #{app_env_name}`
     end
+  end
+
+  def valid_heroku_name(name, element)
+    while name.length > HEROKU_NAMES_MAX_CHARS
+      puts "Heroku names must be shorter than #{HEROKU_NAMES_MAX_CHARS} chars."
+      name = Ask.input("Please enter a valid name for #{element}:")
+    end
+    name
   end
 end

--- a/lib/potassium/recipes/heroku.rb
+++ b/lib/potassium/recipes/heroku.rb
@@ -65,7 +65,7 @@ class Recipes::Heroku < Rails::AppBuilder
   end
 
   def heroku_pipeline_name
-    @heroku_pipeline_name ||= valid_heroku_name(app_name.dasherize, 'pipeline')
+    @heroku_pipeline_name ||= valid_heroku_name(app_name.dasherize, 'pipeline', false)
   end
 
   def set_app_name_for(environment)
@@ -133,10 +133,16 @@ class Recipes::Heroku < Rails::AppBuilder
     end
   end
 
-  def valid_heroku_name(name, element)
+  def valid_heroku_name(name, element, force_suffix = true)
+    suffix = "-#{element}"
     while name.length > HEROKU_NAMES_MAX_CHARS
       puts "Heroku names must be shorter than #{HEROKU_NAMES_MAX_CHARS} chars."
+      if force_suffix
+        puts "Potassium uses the heroku-stage gem, because of that '#{suffix}' will be "\
+             "added to your app name. The suffix, #{suffix}, counts towards the app name length."
+      end
       name = Ask.input("Please enter a valid name for #{element}:")
+      name += suffix if force_suffix && !name.end_with?(suffix)
     end
     name
   end


### PR DESCRIPTION
**Description**
Closes #331 

When the default app name or default pipeline name exceeds 30 characters (the limit set by Heroku), the user is prompted to input a new name. This name doesn't have to include either the name prefix or the environment name at the end (should we enforce that?).

Heroku app names are now set during the ask section of the recipe. This is because it doesn't make sense to ask a user for a Heroku app name if they don't want to deploy the app.