### PR TITLE
chore(): release v6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 6.2.0
+
 Features:
   - Add Google Tag Manager [#326](https://github.com/platanus/potassium/pull/326)
   - Update rubocop and rubocop-rspec for potassium and generated projects [#337](https://github.com/platanus/potassium/pull/337)

--- a/lib/potassium/version.rb
+++ b/lib/potassium/version.rb
@@ -1,5 +1,5 @@
 module Potassium
-  VERSION = "6.1.0"
+  VERSION = "6.2.0"
   RUBY_VERSION = "2.7.0"
   RAILS_VERSION = "~> 6.0.2"
   RUBOCOP_VERSION = "~> 1.9"


### PR DESCRIPTION
Release con las últimas cosas que tenemos en Unreleased:

Features:
  - Add Google Tag Manager [#326](https://github.com/platanus/potassium/pull/326)
  - Update rubocop and rubocop-rspec for potassium and generated projects [#337](https://github.com/platanus/potassium/pull/337)
  - Adds `mailers` queue to `sidekiq.yml` when installing or creating mailer recipe [#341](https://github.com/platanus/potassium/pull/341)

Fixes:
  - Change `backgroud_processor` cli option to a switch. As of [#137](https://github.com/platanus/potassium/pull/137) we no longer have `delayed_jobs` as an option, it's only `sidekiq` now [#340](https://github.com/platanus/potassium/pull/340)
  - Fixes mailer recipe install when background_processor wasn't installed [#341](https://github.com/platanus/potassium/pull/341)
  - Update `heroku` recipe to check if an app or pipeline name is valid before creating it on Heroku [#344](https://github.com/platanus/potassium/pull/344)