### PR TITLE
Feat/webpacker addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features
+  - Updates ActiveAdmin installation to use webpacker [#350](https://github.com/platanus/potassium/pull/350)
+  - Replaces Active Skin with Arctic Admin [#350](https://github.com/platanus/potassium/pull/350)
+
 ## 6.3.0
 
 Features:

--- a/lib/potassium/recipes/admin.rb
+++ b/lib/potassium/recipes/admin.rb
@@ -34,10 +34,9 @@ class Recipes::Admin < Rails::AppBuilder
   def add_active_admin
     gather_gem 'activeadmin', '~> 2.6'
     gather_gem 'activeadmin_addons'
-    gather_gem 'active_skin', github: 'SoftwareBrothers/active_skin'
     add_readme_section :internal_dependencies, :active_admin
     after(:gem_install, wrap_in_action: :admin_install) do
-      generate "active_admin:install"
+      generate "active_admin:install --use_webpacker"
       line = "ActiveAdmin.setup do |config|"
       initializer = "config/initializers/active_admin.rb"
       gsub_file initializer, /(#{Regexp.escape(line)})/mi do |_match|
@@ -50,22 +49,6 @@ class Recipes::Admin < Rails::AppBuilder
           end\n
           ActiveAdmin.setup do |config|
             config.view_factory.footer = CustomFooter
-        HERE
-      end
-
-      line = "@import \"active_admin/base\";"
-      style = "app/assets/stylesheets/active_admin.css.scss"
-      style = File.exist?(style) ? style : "app/assets/stylesheets/active_admin.scss"
-
-      gsub_file style, /(#{Regexp.escape(line)})/mi do |_match|
-        <<~HERE
-          #{line}
-          $skinActiveColor: #001CEE;
-          $skinHeaderBck: #002744;
-          $panelHeaderBck: #002744;
-          //$skinLogo: $skinHeaderBck image-url("logo_admin.png") no-repeat center center;
-
-          @import "active_skin";
         HERE
       end
 

--- a/lib/potassium/recipes/admin.rb
+++ b/lib/potassium/recipes/admin.rb
@@ -49,10 +49,37 @@ class Recipes::Admin < Rails::AppBuilder
           end\n
           ActiveAdmin.setup do |config|
             config.view_factory.footer = CustomFooter
+            meta_tags_options = { viewport: 'width=device-width, initial-scale=1' }
+            config.meta_tags = meta_tags_options
+            config.meta_tags_for_logged_out_pages = meta_tags_options
         HERE
       end
 
       generate "activeadmin_addons:install"
+
+      run "bin/yarn add arctic_admin @fortawesome/fontawesome-free"
+
+      aa_style = "app/javascript/stylesheets/active_admin.scss"
+
+      gsub_file(
+        aa_style,
+        "@import \"~@activeadmin/activeadmin/src/scss/mixins\";\n" +
+        "@import \"~@activeadmin/activeadmin/src/scss/base\";",
+        "@import '~arctic_admin/src/scss/main'; \n"
+      )
+
+      aa_js = "app/javascript/packs/active_admin.js"
+      js_line = "import \"@activeadmin/activeadmin\";\n"
+
+      gsub_file(
+        aa_js,
+        js_line,
+        <<~HERE
+          #{js_line}
+          import '@fortawesome/fontawesome-free/css/all.css';
+          import 'arctic_admin';
+        HERE
+      )
     end
   end
 end

--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -15,13 +15,11 @@ class Recipes::FrontEnd < Rails::AppBuilder
   end
 
   def create
-    return if [:none, :None].include? get(:front_end).to_sym
-
     recipe = self
     after(:gem_install) do
       value = get(:front_end)
       run "rails webpacker:install"
-      run "rails webpacker:install:#{value}" if value
+      run "rails webpacker:install:#{value}" unless [:none, :None].include? value.to_sym
 
       if value == :vue
         recipe.setup_vue_with_compiler_build

--- a/lib/potassium/templates/application.rb
+++ b/lib/potassium/templates/application.rb
@@ -61,8 +61,6 @@ run_action(:recipe_loading) do
   create :better_errors
   create :monitoring
   create :devise
-  create :admin
-  create :vue_admin
   create :seeds
   create :error_reporting
   create :pundit
@@ -78,6 +76,8 @@ run_action(:recipe_loading) do
   create :github
   create :cleanup
   create :front_end
+  create :admin
+  create :vue_admin
   create :google_tag_manager
 end
 

--- a/spec/features/front_end_spec.rb
+++ b/spec/features/front_end_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe "Front end" do
     remove_project_directory
     create_dummy_project("front_end" => "None")
     expect(gemfile).to include('webpacker')
-    expect(File).not_to exist(application_css_path)
   end
 
   def expect_to_have_tailwind_compatibility_build


### PR DESCRIPTION
Makes the necessary changes to use activeadmin in webpacker mode:

- Removes Active Skin
- Forces tailwind 1.9.6 since the default install breaks. #349 covers the update to v2
- Moves the installation of activeadmin to after the webpacker install has run.
- Webpacker (and the frontend section) always runs.

Shouldn't be merged until a new version of activeadmin_addons has been released.

![chrome_USK5WUhw6r](https://user-images.githubusercontent.com/472791/115082256-9c26ab00-9ed3-11eb-8025-511d3fca8e42.png)
