### PR TITLE
feat/tailwind 2 compat build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features:
 
 Fixes:
   - Explicitly install project specified node version in CircleCI build [#352](https://github.com/platanus/potassium/pull/352)
+  - Fixes `tailwindCSS@^2` incompatibility with `postcss@^7` [#356](https://github.com/platanus/potassium/pull/356)
   - Update marcel gem (shrine's mime type analyzer) to avoid mimemagic dependency [#357](https://github.com/platanus/potassium/pull/357)
 
 ## 6.2.0

--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -69,7 +69,8 @@ class Recipes::FrontEnd < Rails::AppBuilder
   end
 
   def setup_tailwind
-    run 'bin/yarn add tailwindcss'
+    run "bin/yarn add tailwindcss@#{Potassium::TAILWINDCSS}"
+    specify_autoprefixer_postcss_compatibility_versions
     setup_client_css
     remove_server_css_requires
     setup_tailwind_requirements
@@ -145,6 +146,10 @@ class Recipes::FrontEnd < Rails::AppBuilder
         defaultClient: apolloClient,
       })
     JS
+  end
+
+  def specify_autoprefixer_postcss_compatibility_versions
+    run 'bin/yarn -D add postcss@^7 autoprefixer@^9'
   end
 
   def setup_client_css

--- a/lib/potassium/version.rb
+++ b/lib/potassium/version.rb
@@ -7,4 +7,5 @@ module Potassium
   POSTGRES_VERSION = "11.3"
   MYSQL_VERSION = "5.7"
   NODE_VERSION = "12"
+  TAILWINDCSS = "npm:@tailwindcss/postcss7-compat"
 end

--- a/spec/features/front_end_spec.rb
+++ b/spec/features/front_end_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe "Front end" do
     expect(File).not_to exist(application_css_path)
   end
 
+  def expect_to_have_tailwind_compatibility_build
+    expect(node_modules_file).to include("\"tailwindcss\": \"npm:@tailwindcss/postcss7-compat\"")
+    expect(node_modules_file).to include("\"autoprefixer\": \"^9\"")
+    expect(node_modules_file).to include("\"postcss\": \"^7\"")
+  end
+
   context "with vue" do
     before(:all) do
       remove_project_directory
@@ -55,6 +61,10 @@ RSpec.describe "Front end" do
       expect(tailwind_config_file).to include('module.exports')
     end
 
+    it 'includes correct packages for tailwind, postcss and autoprefixer compatibility build' do
+      expect_to_have_tailwind_compatibility_build
+    end
+
     context "with graphql" do
       before(:all) do
         remove_project_directory
@@ -83,6 +93,10 @@ RSpec.describe "Front end" do
 
     it "creates application_js_file for tailwind without vue" do
       expect(application_js_file).to include("import '../css/application.css';")
+    end
+
+    it 'includes correct packages for tailwind, postcss and autoprefixer compatibility build' do
+      expect_to_have_tailwind_compatibility_build
     end
   end
 end


### PR DESCRIPTION
## Context

TailwindCSS 2 is compatible with PostCSS 8, but Webpack 4 enforces PostCSS 7, which breaks the generated project if the user does not explicitly specify a lower version of Tailwind (e.g. `1.9.2`) or fixes this issue.

## Changes

Uses the special Tailwind 2 `tailwindcss@npm:@tailwindcss/postcss7-compat` package version that is compatible with `postcss@^7` in generated projects. This change should not be needed anymore when `@rails/webpacker@^6` is released and upgraded in Potassium.

Both `postcss@^7` and `autoprefixer@^9` aren't strictly needed as dependencies because they are also dependencies of `@rails/webpacker@4.3.0` and are installed anyways. Nevertheless, I'd rather explicitly specify the dependencies of this compatibility build.

Changes might conflict with the ones done in #350 relative to TailwindCSS version.

Closes #349