### PR TITLE
refactor/vue webpack aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
 Fixes:
   - Explicitly install project specified node version in CircleCI build [#352](https://github.com/platanus/potassium/pull/352)
   - Update marcel gem (shrine's mime type analyzer) to avoid mimemagic dependency [#357](https://github.com/platanus/potassium/pull/357)
+  - Add Vue alias in the Webpacker config to avoid strange behaviors of external packages [#360](https://github.com/platanus/potassium/pull/358)
 
 ## 6.2.0
 

--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -26,6 +26,7 @@ class Recipes::FrontEnd < Rails::AppBuilder
       if value == :vue
         recipe.setup_vue_with_compiler_build
         recipe.setup_jest
+        recipe.setup_vue_aliases
         if get(:api) == :graphql
           recipe.setup_apollo
         end
@@ -104,6 +105,15 @@ class Recipes::FrontEnd < Rails::AppBuilder
       'app/javascript/packs/application.js',
       "\n    apolloProvider,",
       after: "components: { App },"
+    )
+  end
+
+  def setup_vue_aliases
+    webpack_env_file = 'config/webpack/environment.js'
+    insert_into_file(
+      webpack_env_file,
+      webpack_vue_aliases,
+      before: "module.exports = environment"
     )
   end
 
@@ -195,6 +205,18 @@ class Recipes::FrontEnd < Rails::AppBuilder
         });
 
         return app;
+      });
+    JS
+  end
+
+  def webpack_vue_aliases
+    <<~JS
+      environment.config.merge({
+        resolve: {
+          alias: {
+            'vue$': 'vue/dist/vue.esm.js',
+          },
+        },
       });
     JS
   end

--- a/spec/features/front_end_spec.rb
+++ b/spec/features/front_end_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Front end" do
   let(:application_css_file) { IO.read(application_css_path) }
   let(:tailwind_config_file) { IO.read("#{project_path}/tailwind.config.js") }
   let(:rails_css_file) { IO.read("#{project_path}/app/assets/stylesheets/application.css") }
+  let(:environment_file) { IO.read("#{project_path}/config/webpack/environment.js") }
 
   it "creates a project without a front end framework" do
     remove_project_directory
@@ -44,6 +45,11 @@ RSpec.describe "Front end" do
       expect(application_js_file).to include("import '../css/application.css';")
       expect(layout_file).to include("<%= stylesheet_pack_tag 'application' %>")
       expect(rails_css_file).not_to include('*= require_tree', '*= require_self')
+    end
+
+    it "creates project with a vue module alias included" do
+      expect(environment_file).to include("environment.config.merge({")
+      expect(environment_file).to include("'vue$': 'vue/dist/vue.esm.js',")
     end
 
     it "creates a vue project with tailwindcss" do


### PR DESCRIPTION
## Context
Rails uses the es-module version of Vue when installing it with `rails webpacker:install`, which resolves to the `vue/dist/vue.esm.js` file.

This brings some strange behaviors when using libraries that import the default Vue instance (just `vue`).

## Changes
Add a Webpack alias inside the configuration to resolve all 'vue' imports to the es-module version.

Closes #359 