### PR TITLE
fix(recipes/front_end): add jsdom explicitly as test environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Fixes:
   - Explicitly install project specified node version in CircleCI build [#352](https://github.com/platanus/potassium/pull/352)
   - Fixes `tailwindCSS@^2` incompatibility with `postcss@^7` [#356](https://github.com/platanus/potassium/pull/356)
   - Update marcel gem (shrine's mime type analyzer) to avoid mimemagic dependency [#357](https://github.com/platanus/potassium/pull/357)
+  - Explicitly set the frontend test environment to `jsdom` [#367](https://github.com/platanus/potassium/pull/367)
 
 ## 6.2.0
 

--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -269,7 +269,8 @@ class Recipes::FrontEnd < Rails::AppBuilder
         },
         "snapshotSerializers": [
           "<rootDir>/node_modules/jest-serializer-vue"
-        ]
+        ],
+        "testEnvironment": "jsdom"
       }
     }
   end


### PR DESCRIPTION
Jest v27 changed some defaults. The default test environment changed from `jsdom` to `node`. This breaks our current app spec.

More information in [this response](https://github.com/vuejs/vue-test-utils/issues/999#issuecomment-850273753)