### PR TITLE
chore(circleci): publish to rubygems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,31 @@ jobs:
             cat tmp/files_to_lint | grep -E '.+\.(rb)$' | xargs bundle exec rubocop --force-exclusion \
             | ./bin/reviewdog -reporter=github-pr-review -f=rubocop
 
+  deploy:
+    executor: ruby-executor
+    steps:
+      - setup
+
+      - run:
+          name: Setup rubygems
+          command: bash .circleci/setup-rubygems.sh
+
+      - run:
+          name: Publish to rubygems
+          command: |
+            gem build potassium.gemspec
+            gem push potassium-$(git describe --tags).gem
+
 workflows:
   test_and_lint:
     jobs:
       - test
       - lint:
           context: org-global
+      - deploy:
+          context: org-global
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/setup-rubygems.sh
+++ b/.circleci/setup-rubygems.sh
@@ -1,0 +1,3 @@
+mkdir ~/.gem
+echo -e "---\r\n:rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
+chmod 0600 /home/circleci/.gem/credentials

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ It's important to remember that `bin/potassium_test create`:
 - Can receive the same options as `potassium create`
 - Runs with options with a default value. This is to avoid the "asking part" of the creation process. You need to enable what you want to test like this: `$ bin/potassium_test create --clockwork`
 
+## Publishing
+On master branch.
+
+1. Change `VERSION` in `lib/potassium/version.rb`
+2. Change `Unreleased` title to current version in `CHANGELOG.md`
+3. Commit new release. For example: `Releasing v6.3.0`
+4. Create tag. For example: `git tag v6.3.0`
+5. Push tag: `git push origin v6.3.0`
+
 ## Contributing
 
 If you want to add functionality please go to


### PR DESCRIPTION
Implements the same [circleci deploy mechanism](https://github.com/platanus/parxer/blob/787e0d3e138ed33323362402d5ea5e896c2662f8/.circleci/config.yml#L73) as in [parxer](https://github.com/platanus/parxer)