### PR TITLE
Vue fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Features
   - Updates ActiveAdmin installation to use webpacker [#350](https://github.com/platanus/potassium/pull/350)
   - Replaces Active Skin with Arctic Admin [#350](https://github.com/platanus/potassium/pull/350)
 
+Fixes
+  - Forces `vue-loader` version to 15, as 16 requires `@vue/compiler-sfc`, which is a part of Vue 3
+  - Changes Content Security Policy added by GTM recipe to:
+    - Include the same config regardless of environment
+    - Include `unsafe_eval` in `script_src`, as it is required for Vue's compiler build
+
 ## 6.3.0
 
 Features:

--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -1,4 +1,6 @@
 class Recipes::FrontEnd < Rails::AppBuilder
+  VUE_LOADER_VERSION = Potassium::VUE_LOADER_VERSION
+
   def ask
     frameworks = {
       vue: "Vue",
@@ -100,7 +102,12 @@ class Recipes::FrontEnd < Rails::AppBuilder
     )
   end
 
+  def foce_vue_loader_version
+    run "bin/yarn add vue-loader@#{VUE_LOADER_VERSION}"
+  end
+
   def setup_vue
+    foce_vue_loader_version
     setup_vue_with_compiler_build
     setup_jest
     if get(:api) == :graphql

--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -21,13 +21,7 @@ class Recipes::FrontEnd < Rails::AppBuilder
       run "rails webpacker:install"
       run "rails webpacker:install:#{value}" unless [:none, :None].include? value.to_sym
 
-      if value == :vue
-        recipe.setup_vue_with_compiler_build
-        recipe.setup_jest
-        if get(:api) == :graphql
-          recipe.setup_apollo
-        end
-      end
+      recipe.setup_vue if value == :vue
       recipe.add_responsive_meta_tag
       recipe.setup_tailwind
       add_readme_header :webpack
@@ -104,6 +98,14 @@ class Recipes::FrontEnd < Rails::AppBuilder
       "\n    apolloProvider,",
       after: "components: { App },"
     )
+  end
+
+  def setup_vue
+    setup_vue_with_compiler_build
+    setup_jest
+    if get(:api) == :graphql
+      setup_apollo
+    end
   end
 
   private

--- a/lib/potassium/recipes/google_tag_manager.rb
+++ b/lib/potassium/recipes/google_tag_manager.rb
@@ -68,22 +68,26 @@ class Recipes::GoogleTagManager < Rails::AppBuilder
   def content_security_policy_code
     <<~HERE
       Rails.application.config.content_security_policy do |policy|
-        if Rails.env.development?
-          policy.connect_src :self, :https, 'http://localhost:3035', 'ws://localhost:3035'
-          policy.script_src :self, :https, :unsafe_eval
-        else
-          policy.script_src :self, :https
-          # google tag manager requires to enable unsafe inline:
-          # https://developers.google.com/tag-manager/web/csp
-          policy.connect_src :self, :https, 'https://www.google-analytics.com'
-          policy.script_src :self,
-            :https,
-            :unsafe_inline,
-            'https://www.googletagmanager.com',
-            'https://www.google-analytics.com',
-            'https://ssl.google-analytics.com'
-          policy.img_src :self, :https, 'https://www.googletagmanager.com', 'https://www.google-analytics.com'
-        end
+        policy.connect_src(
+          :self,
+          :https,
+          'http://localhost:3035',
+          'ws://localhost:3035',
+          'https://www.google-analytics.com'
+        )
+        # google tag manager requires to enable unsafe inline and vue unsave eval:
+        # https://developers.google.com/tag-manager/web/csp
+        # https://vuejs.org/v2/guide/installation.html#CSP-environments
+        policy.script_src(
+          :self,
+          :https,
+          :unsafe_inline,
+          :unsafe_eval,
+          'https://www.googletagmanager.com',
+          'https://www.google-analytics.com',
+          'https://ssl.google-analytics.com'
+        )
+        policy.img_src :self, :https, 'https://www.googletagmanager.com', 'https://www.google-analytics.com'
       end
     HERE
   end

--- a/lib/potassium/version.rb
+++ b/lib/potassium/version.rb
@@ -8,4 +8,5 @@ module Potassium
   MYSQL_VERSION = "5.7"
   NODE_VERSION = "12"
   TAILWINDCSS = "npm:@tailwindcss/postcss7-compat"
+  VUE_LOADER_VERSION = "^15.9.7"
 end

--- a/spec/features/front_end_spec.rb
+++ b/spec/features/front_end_spec.rb
@@ -64,6 +64,10 @@ RSpec.describe "Front end" do
       expect_to_have_tailwind_compatibility_build
     end
 
+    it 'includes correct version of vue-loader in package' do
+      expect(node_modules_file).to include("\"vue-loader\": \"#{Potassium::VUE_LOADER_VERSION}\"")
+    end
+
     context "with graphql" do
       before(:all) do
         remove_project_directory

--- a/spec/features/google_tag_manager_spec.rb
+++ b/spec/features/google_tag_manager_spec.rb
@@ -31,29 +31,6 @@ RSpec.describe "Google Tag Manager" do
 
   it 'add content security policy' do
     expect(content_security_policy_file)
-      .to include(content_security_policy_code)
-  end
-
-  def content_security_policy_code
-    <<~HERE
-      Rails.application.config.content_security_policy do |policy|
-        if Rails.env.development?
-          policy.connect_src :self, :https, 'http://localhost:3035', 'ws://localhost:3035'
-          policy.script_src :self, :https, :unsafe_eval
-        else
-          policy.script_src :self, :https
-          # google tag manager requires to enable unsafe inline:
-          # https://developers.google.com/tag-manager/web/csp
-          policy.connect_src :self, :https, 'https://www.google-analytics.com'
-          policy.script_src :self,
-            :https,
-            :unsafe_inline,
-            'https://www.googletagmanager.com',
-            'https://www.google-analytics.com',
-            'https://ssl.google-analytics.com'
-          policy.img_src :self, :https, 'https://www.googletagmanager.com', 'https://www.google-analytics.com'
-        end
-      end
-    HERE
+      .to include("\nRails.application.config.content_security_policy do |policy|")
   end
 end


### PR DESCRIPTION
### Changes

This PR addresses 2 Vue related bugs that have been appearing recently:

- In front_end recipe, when choosing value Vue, `rails webpacker:install:vue` is called. This, among other things, adds `vue` v2 and `vue-loader` at it's latest version. Problem is, vue-loader v16 (latest) [requires @vue/compiler-sfc](https://github.com/vuejs/vue-loader/releases/tag/v16.0.0) which [is a part of vue-next](https://github.com/vuejs/vue-next/tree/master/packages/compiler-sfc), aka Vue 3. This results in a dependency error. To fix this, recipe now forces version 15 of vue-loader, calling `yarn add` after webpacker install
- When selecting GMT recipe + Vue in frontend, app wasn't rendering when deployed. This was due to Content Security Policy added by GMT policy, it had a difference between dev and prod environments that was preventing vue from correctly mounting itself in the latter. To solve this, I changed two things:
  - I put the same configuration regardless of environment. Some things might not make sense for production, like the `localhost:3035` for `webpack-dev-server`. I'm not 100% sure about this decision, I don't think there's any harm in including it and I wanted to have the same config so that any problems like this could be caught earlier, in dev env. Would like a second opinion on this though
  - I included `unsafe_eval` for `script_src` policy, which is [needed for Vue compiler build](https://vuejs.org/v2/guide/installation.html#CSP-environments)

Small testing detail, in GTM test I changed the CSP part of the test to just look for the initial line of the config, to avoid having to duplicate all the config in the test when changing the CSP config