### PR TITLE
chore(assets/app/js/app.spec.js): remove deprecated method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Fixes
   - Changes Content Security Policy added by GTM recipe to:
     - Include the same config regardless of environment
     - Include `unsafe_eval` in `script_src`, as it is required for Vue's compiler build
+  - Changes the front-end test to avoid using the deprecated method `isVueInstance` [#376](https://github.com/platanus/potassium/pull/376)
 
 ## 6.3.0
 

--- a/lib/potassium/assets/app/javascript/app.spec.js
+++ b/lib/potassium/assets/app/javascript/app.spec.js
@@ -4,7 +4,7 @@ import App from 'app';
 describe('App', () => {
   test('is a Vue instance', () => {
     const wrapper = shallowMount(App);
-    expect(wrapper.isVueInstance()).toBeTruthy();
+    expect(wrapper.vm).toBeTruthy();
   });
 
   it('displays message on load', () => {


### PR DESCRIPTION
The `isVueInstance` method [is deprecated](https://vue-test-utils.vuejs.org/api/wrapper-array/isvueinstance.html) and triggers a warning.
The proposed way [tests exactly the same](https://github.com/vuejs/vue-test-utils/blob/2d6b49780c7e1d663b877ddf5d6492ed7b510379/packages/test-utils/src/wrapper.js#L400) but avoids the warning message.