### PR TITLE
Release 6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ Features
   - Replaces Active Skin with Arctic Admin [#350](https://github.com/platanus/potassium/pull/350)
 
 Fixes
-  - Forces `vue-loader` version to 15, as 16 requires `@vue/compiler-sfc`, which is a part of Vue 3
-  - Changes Content Security Policy added by GTM recipe to:
+  - Forces `vue-loader` version to 15, as 16 requires `@vue/compiler-sfc`, which is a part of Vue 3 [#375](https://github.com/platanus/potassium/pull/375)
+  - Changes Content Security Policy added by GTM recipe to: [#375](https://github.com/platanus/potassium/pull/375)
     - Include the same config regardless of environment
     - Include `unsafe_eval` in `script_src`, as it is required for Vue's compiler build
   - Changes the front-end test to avoid using the deprecated method `isVueInstance` [#376](https://github.com/platanus/potassium/pull/376)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 6.4.0
+
 Features
   - Updates ActiveAdmin installation to use webpacker [#350](https://github.com/platanus/potassium/pull/350)
   - Replaces Active Skin with Arctic Admin [#350](https://github.com/platanus/potassium/pull/350)

--- a/lib/potassium/version.rb
+++ b/lib/potassium/version.rb
@@ -1,5 +1,5 @@
 module Potassium
-  VERSION = "6.3.0"
+  VERSION = "6.4.0"
   RUBY_VERSION = "2.7.0"
   RAILS_VERSION = "~> 6.0.2"
   RUBOCOP_VERSION = "~> 1.9"


### PR DESCRIPTION
Features
  - Updates ActiveAdmin installation to use webpacker [#350](https://github.com/platanus/potassium/pull/350)
  - Replaces Active Skin with Arctic Admin [#350](https://github.com/platanus/potassium/pull/350)

Fixes
  - Forces `vue-loader` version to 15, as 16 requires `@vue/compiler-sfc`, which is a part of Vue 3 [#375](https://github.com/platanus/potassium/pull/375)
  - Changes Content Security Policy added by GTM recipe to: [#375](https://github.com/platanus/potassium/pull/375)
    - Include the same config regardless of environment
    - Include `unsafe_eval` in `script_src`, as it is required for Vue's compiler build
  - Changes the front-end test to avoid using the deprecated method `isVueInstance` [#376](https://github.com/platanus/potassium/pull/376)