### PR TITLE
Active Admin - Pundit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Features
   - Update node to latest LTS version, 14 [#363](https://github.com/platanus/potassium/pull/363)
   - Update ActiveAdmin to 2.9 to fix CSV streaming issues [#384](https://github.com/platanus/potassium/pull/384)
+  - Separates Pundit's configuration for Active Admin from Application's configuration
 
 Fixes
   - Remove rails_stdout_logging gem because it is no longer needed after Rails 5 and it was generating a deprecation warning [#325](https://github.com/platanus/potassium/pull/325)

--- a/lib/potassium/assets/README.yml
+++ b/lib/potassium/assets/README.yml
@@ -153,6 +153,26 @@ readme:
               ```
               - You can also use **any** vue bindings such as `v-for` , `:key` etc.
             <% end %>
+            <% if get(:authorization) %>
+            It uses the [ActiveAdmin's Pundit adapter](https://activeadmin.info/13-authorization-adapter.html).
+            - Policies for admin resources must inherit from `BackOffice::DefaultPolicy` and be placed inside the `app/policies/back_office` directory.
+              - For example:
+
+                `app/admin/clients.rb`:
+
+                ```ruby
+                ActiveAdmin.register Client do
+                  # ...
+                end
+                ```
+
+                `app/policies/back_office/client_policy.rb`:
+
+                ```ruby
+                class BackOffice::ClientPolicy < BackOffice::DefaultPolicy
+                end
+                ```
+            <% end %>
     seeds:
       title: "Seeds"
       body: |

--- a/lib/potassium/assets/active_admin/admin_user_policy.rb
+++ b/lib/potassium/assets/active_admin/admin_user_policy.rb
@@ -1,2 +1,0 @@
-class AdminUserPolicy < ApplicationPolicy
-end

--- a/lib/potassium/assets/active_admin/comment_policy.rb
+++ b/lib/potassium/assets/active_admin/comment_policy.rb
@@ -1,2 +1,0 @@
-class ActiveAdmin::CommentPolicy < ApplicationPolicy
-end

--- a/lib/potassium/assets/active_admin/policies/admin_user_policy.rb
+++ b/lib/potassium/assets/active_admin/policies/admin_user_policy.rb
@@ -1,0 +1,2 @@
+class BackOffice::AdminUserPolicy < BackOffice::DefaultPolicy
+end

--- a/lib/potassium/assets/active_admin/policies/comment_policy.rb
+++ b/lib/potassium/assets/active_admin/policies/comment_policy.rb
@@ -1,0 +1,2 @@
+class BackOffice::ActiveAdmin::CommentPolicy < BackOffice::DefaultPolicy
+end

--- a/lib/potassium/assets/active_admin/policies/default_policy.rb
+++ b/lib/potassium/assets/active_admin/policies/default_policy.rb
@@ -1,0 +1,49 @@
+class BackOffice::DefaultPolicy
+  attr_reader :admin_user, :record
+
+  def initialize(admin_user, record)
+    @admin_user = admin_user
+    @record = record
+  end
+
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    true
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    true
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    true
+  end
+
+  class Scope
+    attr_reader :admin_user, :scope
+
+    def initialize(admin_user, scope)
+      @admin_user = admin_user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/lib/potassium/assets/active_admin/policies/page_policy.rb
+++ b/lib/potassium/assets/active_admin/policies/page_policy.rb
@@ -1,0 +1,2 @@
+class BackOffice::ActiveAdmin::PagePolicy < BackOffice::DefaultPolicy
+end

--- a/lib/potassium/assets/active_admin/pundit_page_policy.rb
+++ b/lib/potassium/assets/active_admin/pundit_page_policy.rb
@@ -1,5 +1,0 @@
-class ActiveAdmin::PagePolicy < ApplicationPolicy
-  def show?
-    true
-  end
-end

--- a/spec/features/pundit_spec.rb
+++ b/spec/features/pundit_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+RSpec.describe "Pundit" do
+  before :all do
+    drop_dummy_database
+    remove_project_directory
+    create_dummy_project("pundit" => true, "devise" => true, "admin" => true)
+  end
+
+  it "adds the Pundit gem to Gemfile" do
+    content = IO.read("#{project_path}/Gemfile")
+
+    expect(content).to include("gem 'pundit'")
+  end
+
+  it "setup active admin" do
+    content = IO.read("#{project_path}/config/initializers/active_admin.rb")
+
+    expect(content).to include("config.authorization_adapter = ActiveAdmin::PunditAdapter")
+    expect(content).to include("config.pundit_default_policy = 'BackOffice::DefaultPolicy'")
+    expect(content).to include("config.pundit_policy_namespace = :back_office")
+  end
+
+  it "creates default policy" do
+    content = IO.read("#{project_path}/app/policies/back_office/default_policy.rb")
+
+    expect(content).to include("class BackOffice::DefaultPolicy")
+  end
+
+  it "modifies the README file" do
+    readme = IO.read("#{project_path}/README.md")
+    expect(readme).to include("from `BackOffice::DefaultPolicy`")
+  end
+end


### PR DESCRIPTION
Different pundit settings for app and Active Admin.
Active admin policies now go inside the `BackOffice` namespace.
Active admin policies now inherit from `BackOffice::DefaultPolicy`.