### PR TITLE
feat(rubocop): add run_test! example group for swagger in rpsec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 Features
+  - Include `run_test` as a valid example group [#379](https://github.com/platanus/potassium/pull/379)
   - Updates ActiveAdmin installation to use webpacker [#350](https://github.com/platanus/potassium/pull/350)
   - Replaces Active Skin with Arctic Admin [#350](https://github.com/platanus/potassium/pull/350)
 

--- a/lib/potassium/recipes/api.rb
+++ b/lib/potassium/recipes/api.rb
@@ -38,6 +38,7 @@ class Recipes::Api < Rails::AppBuilder
     end
 
     add_readme_section :internal_dependencies, :power_api
+    append_to_file('.rubocop.yml', "RSpec:\n  Includes:\n    Examples:\n      - run_test!")
 
     after(:gem_install) do
       generate "power_api:install"


### PR DESCRIPTION
# Objective
Include `run_test!` to Rspec example groups for swagger API documentation/testing. 
This is mentioned in issue #362.