### PR TITLE
feat(ci): add env var to cache key to allow clearing it

### DIFF
--- a/lib/potassium/assets/.circleci/config.yml.erb
+++ b/lib/potassium/assets/.circleci/config.yml.erb
@@ -37,12 +37,12 @@ commands:
 
       - restore_cache:
           keys:
-          - bundle-dependencies-{{ checksum "Gemfile.lock" }}
+          - bundle-dependencies-{{ .Environment.BUNDLE_CACHE_VERSION }}-{{ checksum "Gemfile.lock" }}
           - bundle-dependencies-
 
       - restore_cache:
           keys:
-          - yarn-dependencies-{{ checksum "yarn.lock" }}
+          - yarn-dependencies-{{ .Environment.YARN_CACHE_VERSION }}-{{ checksum "yarn.lock" }}
           - yarn-dependencies-
 
       - run:
@@ -62,12 +62,12 @@ commands:
             yarn install --frozen-lockfile
 
       - save_cache:
-          key: bundle-dependencies-{{ checksum "Gemfile.lock" }}
+          key: bundle-dependencies-{{ .Environment.BUNDLE_CACHE_VERSION }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
 
       - save_cache:
-          key: yarn-dependencies-{{ checksum "yarn.lock" }}
+          key: yarn-dependencies-{{ .Environment.YARN_CACHE_VERSION }}-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
 


### PR DESCRIPTION
closes #381

I added the ability of clearing the cache with two different env vars, to differentiate between bundler cache and yarn cache.

To use this new feature to "clear" the cache, one can go to the env vars section in the projects settings tab in CircleCI and add/change the `BUNDLE_CACHE_VERSION` or the `YARN_CACHE_VERSION` env var with something like v1 or v2 and so on. If the var is new, the restore cache steps of the build won't find anything and it will proceed without a hit. Then, a new cache will be saved.