### PR TITLE
fix(pryrc): remove ConsoleMethods

### DIFF
--- a/lib/potassium/assets/.pryrc
+++ b/lib/potassium/assets/.pryrc
@@ -4,9 +4,3 @@ if defined?(PryByebug)
   Pry.commands.alias_command 'n', 'next'
   Pry.commands.alias_command 'f', 'finish'
 end
-
-if defined?(Rails)
-  require 'rails/console/app'
-  require 'rails/console/helpers'
-  include Rails::ConsoleMethods # rubocop:disable Style/MixinUsage
-end


### PR DESCRIPTION
### Context

With our potassium setup, there's a bug that causes activeadmin resources default actions (view/edit/delete) to not appear after using `binding.pry`. The only working solution when that happens is to restart the server.

### Cause of the bug and solution

I did a little digging, and found out that the bug was caused because of the piece of code that this PR removes:

The `include Rails::ConsoleMethods` was adding some methods, in particular `reload!`, to the pry session, probably because of [this notice in pry docs](https://github.com/pry/pry/wiki/Setting-up-Rails-or-Heroku-to-use-Pry#a-minor-fix-needed-on-rails-32). However, for `rails console`, that was [already being done by the gem `pry-rails`](https://github.com/rweng/pry-rails/blob/master/lib/pry-rails/railtie.rb#L25), so adding this code to the `.pryrc` was only adding the methods to a `binding.pry` session inside a `rails server` instance.
This last part is where the problem was: one of the methods included is [controller](https://api.rubyonrails.org/classes/Rails/ConsoleMethods.html#method-i-controller), which was overriding AA's controller method and making it return a fresh `ApplicationController` every time, instead of the current AA controller. This resulted in AA [asking if the controller had the default action methods](https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/views/index_as_table.rb#L377) and getting `false`, thus not showing the default actions.

As a solution, I just removed the code in pryrc that added those methods. With this you can still call `reload!` in a `rails console` session, but not inside a `binding.pry` in `rails server`. In my experience, it is not very common to do that anyway, so it wouldn't be that much of a problem, but I would love other opinions. Also, if we would like to preserve `reload!` in `binding.pry` an alternative is to define it directly, something [like the else in this answer](https://github.com/pry/pry-rails/issues/9#issuecomment-72305084)