### PR TITLE
chore(): update rails to 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features
   - Update ActiveAdmin to 2.9 to fix CSV streaming issues [#384](https://github.com/platanus/potassium/pull/384)
   - Separates Pundit's configuration for Active Admin from Application's configuration [#378](https://github.com/platanus/potassium/pull/378)
   - Add SimpleCov recipe [#387](https://github.com/platanus/potassium/pull/387)
+  - Update Rails to 6.1 [#389](https://github.com/platanus/potassium/pull/389)
 
 Fixes
   - Remove rails_stdout_logging gem because it is no longer needed after Rails 5 and it was generating a deprecation warning [#325](https://github.com/platanus/potassium/pull/325)

--- a/lib/potassium/version.rb
+++ b/lib/potassium/version.rb
@@ -1,7 +1,7 @@
 module Potassium
   VERSION = "6.4.0"
   RUBY_VERSION = "2.7.0"
-  RAILS_VERSION = "~> 6.0.2"
+  RAILS_VERSION = "~> 6.1.4.1"
   RUBOCOP_VERSION = "~> 1.9"
   RUBOCOP_RSPEC_VERSION = "~> 2.2"
   POSTGRES_VERSION = "11.3"


### PR DESCRIPTION
Webpacker 4 is incompatible with the "newly" released webpack-dev-server@4, which may be breaking new projects created with potassium.

Updating Rails to 6.1 gives us access to Webpacker 5 which fixes the problem by fixing the version of the package to 3.

Mostly a placeholder until Webpacker 6 gets released, with compatibility with wds@4.

---

For existing projects: Upgrading to Rails 6.1 and Webpacker 5 seems to be seamless with our current setup, none of the [changes](https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-6-0-to-rails-6-1) should affect us but of course it depends on the project. Tested with mok and it worked as-is after running the update helper.