### PR TITLE
feat(recepies/api): include 'run_test!' as an example group for swagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features
   - Separates Pundit's configuration for Active Admin from Application's configuration [#378](https://github.com/platanus/potassium/pull/378)
   - Add SimpleCov recipe [#387](https://github.com/platanus/potassium/pull/387)
   - Update Rails to 6.1 [#389](https://github.com/platanus/potassium/pull/389)
+  - Include `run_test` as a valid example group [#379](https://github.com/platanus/potassium/pull/379). This was added incorrectly in this [PR](https://github.com/platanus/potassium/pull/379).
 
 Fixes
   - Remove rails_stdout_logging gem because it is no longer needed after Rails 5 and it was generating a deprecation warning [#325](https://github.com/platanus/potassium/pull/325)

--- a/lib/potassium/recipes/api.rb
+++ b/lib/potassium/recipes/api.rb
@@ -38,7 +38,8 @@ class Recipes::Api < Rails::AppBuilder
     end
 
     add_readme_section :internal_dependencies, :power_api
-    append_to_file('.rubocop.yml', "RSpec:\n  Includes:\n    Examples:\n      - run_test!")
+    rubocop_example = "RSpec:\n  Language:\n    Includes:\n      Examples:\n        - run_test!"
+    append_to_file('.rubocop.yml', rubocop_example)
 
     after(:gem_install) do
       generate "power_api:install"


### PR DESCRIPTION
## Objective
- Add `run_test!` as an example group in rubocop for swagger api.
- This was incorrectly implemented in this previous [PR](https://github.com/platanus/potassium/pull/379).