### PR TITLE
Image handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 Features
   - Update power api gem to use v2.0.0. Install "internal" API mode [#394](https://github.com/platanus/potassium/pull/394)
   - Updates Webpacker to Shakapacker, upgrading Vue and TailwindCSS to their latest versions [#395](https://github.com/platanus/potassium/pull/395)
+  - Add some image handling and processing in shrine file storage option [#398](https://github.com/platanus/potassium/pull/398)
 ## 6.5.0
 
 Features

--- a/lib/potassium/assets/Aptfile
+++ b/lib/potassium/assets/Aptfile
@@ -1,0 +1,5 @@
+libglib2.0-0
+libglib2.0-dev
+libpoppler-glib8
+libwebp-dev
+webp

--- a/lib/potassium/assets/README.yml
+++ b/lib/potassium/assets/README.yml
@@ -105,7 +105,34 @@ readme:
           body: "For managing uploads, this project uses [Active Storage](https://github.com/rails/rails/tree/master/activestorage)."
         shrine:
           title: "File Storage"
-          body: "For managing uploads, this project uses [Shrine](https://github.com/shrinerb/shrine)."
+          body: |
+            For managing uploads, this project uses [Shrine](https://github.com/shrinerb/shrine). When generated, this project includes the following files and configurations:
+
+            - `ImageUploader` that includes file type validation
+            - `CoverImageUploader`, inheriting from `ImageUploader`. It does a couple of things:
+              - Generates derivatives in `jpg` and `webp` format, for three different sizes. For an attachment of name `image`, to get the url for a derivative, let's say `sm`, you would do `record.image_url(:sm)`
+              - Saves a [blurhash](https://blurha.sh/) code to the attachment metadata
+            - `ImageHandlingUtilities`, a shrine plugin in the initializers folder that is used in the `CoverImageUploader`. Given a model with an attachment of name `image`, it adds the following methods to the model:
+              - `image_blurhash`: returns blurhash from metadata
+              - `generate_image_derivatives`: It generates all derivatives defined in Uploader. If file already had derivatives, it replaces them with newly generated ones. Associated class method: `generate_all_image_derivatives`
+              - `generate_image_metadata`: refreshes all metadata for attachment. Associated class method: `generate_all_image_metadata`
+              - `generate_image_derivatives_and_metadata`: does both previous things. Useful because it does so opening the file only once. Associated class method: `generate_all_image_derivatives_and_metadata`
+
+              Class methods are the same as their instance counterparts, but for collections. They also allow error handling on an individual record by passing a block to handle each error. If no block is given, attachments that throw errors are ignored and the iteration continues
+            - `ImageHandlingAttributes` serializer concern. It adds a method `add_image_handling_attributes` to all serializers that inherit from `BaseSerializer`. Considering an attachment of name `image`, this method adds two attributes to the serialized record:
+              - `image_blurhash`
+              - `image`. This is a hash that includes urls for all derivatives passed to the method. For example:
+              ```
+                add_image_handling_attributes(attachment_name: :image, derivatives: [:sm, :md], include_original_image: true)
+
+                # results in the following hash for the image attribute:
+                # {
+                #   sm: { url: 'someurl.com/bla' },
+                #   md: { url: 'someurl.com/ble' },
+                #   original: { url: 'someurl.com/ble' }
+                # }
+              ```
+            - `SHRINE_SECRET_KEY` environment variable. It comes witha value set in `.env.development`, but you'll need to set one for it in staging and production. It can be any random value, generating it with `SecureRandom.hex` for instance
         pundit:
           title: "Authorization"
           body: "For defining which parts of the system each user has access to, we have chosen to include the [Pundit](https://github.com/elabs/pundit) gem, by [Elabs](http://elabs.se/)."

--- a/lib/potassium/assets/app/jobs/shrine_promote_job.rb
+++ b/lib/potassium/assets/app/jobs/shrine_promote_job.rb
@@ -1,0 +1,14 @@
+class ShrinePromoteJob < ApplicationJob
+  queue_as :default
+
+  def perform(attacher_class, record_class, record_id, name, file_data)
+    attacher_class = Object.const_get(attacher_class)
+    record         = Object.const_get(record_class).find(record_id)
+
+    attacher = attacher_class.retrieve(model: record, name: name, file: file_data)
+    attacher.create_derivatives
+    attacher.atomic_promote
+  rescue Shrine::AttachmentChanged, ActiveRecord::RecordNotFound
+    # attachment has changed or the record has been deleted, nothing to do
+  end
+end

--- a/lib/potassium/assets/app/serializers/base_serializer.rb
+++ b/lib/potassium/assets/app/serializers/base_serializer.rb
@@ -1,0 +1,3 @@
+class BaseSerializer < ActiveModel::Serializer
+  include ImageHandlingAttributes
+end

--- a/lib/potassium/assets/app/serializers/concerns/image_handling_attributes.rb
+++ b/lib/potassium/assets/app/serializers/concerns/image_handling_attributes.rb
@@ -1,0 +1,20 @@
+module ImageHandlingAttributes
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def add_image_handling_attributes(attachment_name:, derivatives:, include_original_image: false)
+      attributes attachment_name, "#{attachment_name}_blurhash".to_sym
+
+      define_method(attachment_name) do
+        attachment_hash = derivatives.reduce({}) do |hash, derivative|
+          hash[derivative] = { url: object.send("#{attachment_name}_url", derivative) }
+          hash
+        end
+        if include_original_image
+          attachment_hash[:original] = { url: object.send("#{attachment_name}_url") }
+        end
+        attachment_hash
+      end
+    end
+  end
+end

--- a/lib/potassium/assets/app/uploaders/cover_image_uploader.rb
+++ b/lib/potassium/assets/app/uploaders/cover_image_uploader.rb
@@ -1,0 +1,52 @@
+require "image_processing/vips"
+
+class CoverImageUploader < ImageUploader
+  plugin :derivation_endpoint, prefix: "derivations/cover_image"
+  plugin :add_metadata
+  plugin :image_handling_utilities
+
+  DERIVATIVES = {
+    sm: { size: [426, 240], type: 'jpg' },
+    md: { size: [960, 540], type: 'jpg' },
+    lg: { size: [1280, 720], type: 'jpg' },
+    webp_sm: { size: [426, 240], type: 'webp' },
+    webp_md: { size: [960, 540], type: 'webp' },
+    webp_lg: { size: [1280, 720], type: 'webp' }
+  }
+
+  Attacher.derivatives do |original|
+    vips = ImageProcessing::Vips.source(original)
+
+    DERIVATIVES.reduce({}) do |derivatives_hash, (name, derivative_info)|
+      derivatives_hash[name] = vips.convert(derivative_info[:type]).resize_to_limit!(
+        *derivative_info[:size]
+      )
+      derivatives_hash
+    end
+  end
+
+  derivation :thumbnail do |file, width, height|
+    ImageProcessing::Vips
+      .source(file)
+      .resize_to_limit!(width.to_i, height.to_i)
+  end
+
+  Attacher.default_url do |derivative: nil, **|
+    file&.derivation_url(:thumbnail, *DERIVATIVES.dig(derivative, :size)) if derivative.present?
+  end
+
+  add_metadata :blurhash do |io, derivative: nil, **|
+    if derivative.nil?
+      Shrine.with_file(io) do |file|
+        image = Vips::Image.new_from_file(file.path, access: :sequential)
+        image = image.resize(100.0 / image.width)
+        flat_rgb_pixels = []
+        image.to_a.each do |row|
+          row.each { |pixel| flat_rgb_pixels.concat(pixel[0..2])  }
+        end
+
+        Blurhash.encode(image.width, image.height, flat_rgb_pixels)
+      end
+    end
+  end
+end

--- a/lib/potassium/assets/config/initializers/shrine/plugins/image_handling_utilities.rb
+++ b/lib/potassium/assets/config/initializers/shrine/plugins/image_handling_utilities.rb
@@ -1,0 +1,143 @@
+class Shrine
+  module Plugins
+    module ImageHandlingUtilities
+      # rubocop:disable Metrics/ModuleLength
+      module AttachmentMethods
+        def included(klass)
+          super
+
+          define_instance_methods
+          define_class_methods(klass)
+        end
+
+        private
+
+        def define_instance_methods
+          define_with_stored_attacher_method
+          define_blurhash_instance_method
+          define_generate_derivatives_instance_method
+          define_generate_metadata_instance_method
+          define_generate_derivatives_and_metadata_instance_method
+        end
+
+        def define_blurhash_instance_method
+          name = @name
+          define_method(:"#{@name}_blurhash") do
+            send(name)&.metadata&.[]('blurhash')
+          end
+        end
+
+        def define_generate_derivatives_instance_method
+          name = @name
+          define_method(:"generate_#{name}_derivatives") do
+            send("with_stored_#{name}_attacher") do |attacher|
+              old_derivatives = attacher.derivatives
+
+              attacher.set_derivatives({})
+              attacher.create_derivatives
+
+              begin
+                attacher.atomic_persist
+                attacher.delete_derivatives(old_derivatives) if old_derivatives.present?
+              rescue Shrine::AttachmentChanged, ActiveRecord::RecordNotFound
+                attacher.delete_derivatives
+              end
+            end
+          end
+        end
+
+        def define_generate_metadata_instance_method
+          name = @name
+          define_method(:"generate_#{name}_metadata") do
+            send("with_stored_#{name}_attacher") do |attacher|
+              attacher.refresh_metadata!
+              attacher.atomic_persist
+            end
+          end
+        end
+
+        # rubocop:disable Metrics/MethodLength
+        def define_generate_derivatives_and_metadata_instance_method
+          name = @name
+          define_method(:"generate_#{name}_derivatives_and_metadata") do
+            send("with_stored_#{name}_attacher") do |attacher|
+              old_derivatives = attacher.derivatives
+
+              attacher.set_derivatives({})
+              attacher.file.open do
+                attacher.create_derivatives
+                attacher.refresh_metadata!
+              end
+
+              begin
+                attacher.atomic_persist
+                attacher.delete_derivatives(old_derivatives) if old_derivatives.present?
+              rescue Shrine::AttachmentChanged, ActiveRecord::RecordNotFound
+                attacher.delete_derivatives
+              end
+            end
+          end
+        end
+        # rubocop:enable Metrics/MethodLength
+
+        def define_class_methods(klass)
+          define_generate_all_derivatives_class_method(klass)
+          define_generate_all_metadata_class_method(klass)
+          define_generate_all_derivatives_and_metadata_class_method(klass)
+        end
+
+        def define_generate_all_derivatives_class_method(klass)
+          name = @name
+          klass.send(
+            :define_singleton_method, :"generate_all_#{name}_derivatives"
+          ) do |&error_block|
+            all.find_each do |record|
+              record.send(:"generate_#{name}_derivatives")
+            rescue StandardError => e
+              error_block.call(record, e) if error_block.present?
+            end
+          end
+        end
+
+        def define_generate_all_metadata_class_method(klass)
+          name = @name
+          klass.send(:define_singleton_method, :"generate_all_#{name}_metadata") do |&error_block|
+            all.find_each do |record|
+              record.send(:"generate_#{name}_metadata")
+            rescue StandardError => e
+              error_block.call(record, e) if error_block.present?
+            end
+          end
+        end
+
+        def define_generate_all_derivatives_and_metadata_class_method(klass)
+          name = @name
+          klass.send(
+            :define_singleton_method, :"generate_all_#{name}_derivatives_and_metadata"
+          ) do |&error_block|
+            all.find_each do |record|
+              record.send(:"generate_#{name}_derivatives_and_metadata")
+            rescue StandardError => e
+              error_block.call(record, e) if error_block.present?
+            end
+          end
+        end
+
+        def define_with_stored_attacher_method
+          name = @name
+          define_method(:"with_stored_#{name}_attacher") do |&block|
+            return if send(name).blank?
+
+            attacher = send(:"#{name}_attacher")
+
+            block.call(attacher) if attacher.stored?
+          end
+          private :"with_stored_#{name}_attacher"
+        end
+      end
+      # rubocop:enable Metrics/ModuleLength
+    end
+
+    register_plugin(:image_handling_utilities, ImageHandlingUtilities)
+  end
+end

--- a/lib/potassium/assets/config/shrine.rb
+++ b/lib/potassium/assets/config/shrine.rb
@@ -34,3 +34,18 @@ Shrine.plugin :activerecord
 Shrine.plugin :cached_attachment_data
 Shrine.plugin :restore_cached_data
 Shrine.plugin :determine_mime_type, analyzer: :marcel
+Shrine.plugin :derivatives
+Shrine.plugin :default_url
+Shrine.plugin :derivation_endpoint, secret_key: ENV.fetch('SHRINE_SECRET_KEY')
+Shrine.plugin :refresh_metadata
+Shrine.plugin :backgrounding
+
+Shrine::Attacher.promote_block do |attacher|
+  ShrinePromoteJob.perform_later(
+    attacher.class.name,
+    attacher.record.class.name,
+    attacher.record.id,
+    attacher.name,
+    attacher.file_data
+  )
+end

--- a/lib/potassium/recipes/file_storage.rb
+++ b/lib/potassium/recipes/file_storage.rb
@@ -51,7 +51,7 @@ class Recipes::FileStorage < Rails::AppBuilder
     gather_gem('image_processing', '~> 1.8')
     gather_gem('blurhash', '~> 0.1')
     gather_gem('ruby-vips', '~> 2.1')
-    append_to_file('.env.development', "SHRINE_SECRET_KEY=\n")
+    append_to_file('.env.development', "SHRINE_SECRET_KEY=#{SecureRandom.hex}\n")
     copy_file('../assets/app/jobs/shrine_promote_job.rb', 'app/jobs/shrine_promote_job.rb')
     add_image_handling_plugin
     add_cover_image_uploader

--- a/lib/potassium/recipes/file_storage.rb
+++ b/lib/potassium/recipes/file_storage.rb
@@ -44,6 +44,56 @@ class Recipes::FileStorage < Rails::AppBuilder
     copy_file('../assets/app/uploaders/image_uploader.rb', 'app/uploaders/image_uploader.rb')
     copy_file('../assets/app/uploaders/base_uploader.rb', 'app/uploaders/base_uploader.rb')
     append_to_file('.gitignore', "/public/uploads\n")
+    add_image_handling_and_cover_image_uploader
+  end
+
+  def add_image_handling_and_cover_image_uploader
+    gather_gem('image_processing', '~> 1.8')
+    gather_gem('blurhash', '~> 0.1')
+    gather_gem('ruby-vips', '~> 2.1')
+    append_to_file('.env.development', "SHRINE_SECRET_KEY=\n")
+    copy_file('../assets/app/jobs/shrine_promote_job.rb', 'app/jobs/shrine_promote_job.rb')
+    add_image_handling_plugin
+    add_cover_image_uploader
+    add_image_handling_serializer_concern if get(:api) == :rest
+    add_image_handling_heroku_setup if get(:heroku)
+  end
+
+  def add_cover_image_uploader
+    copy_file(
+      '../assets/app/uploaders/cover_image_uploader.rb', 'app/uploaders/cover_image_uploader.rb'
+    )
+    insert_into_file "config/routes.rb", after: "Rails.application.routes.draw do\n" do
+      <<~HERE.indent(2)
+        mount CoverImageUploader.derivation_endpoint => "/derivations/cover_image"
+      HERE
+    end
+  end
+
+  def add_image_handling_plugin
+    copy_file(
+      '../assets/config/initializers/shrine/plugins/image_handling_utilities.rb',
+      'config/initializers/shrine/plugins/image_handling_utilities.rb'
+    )
+  end
+
+  def add_image_handling_serializer_concern
+    copy_file(
+      '../assets/app/serializers/concerns/image_handling_attributes.rb',
+      'app/serializers/concerns/image_handling_attributes.rb'
+    )
+    copy_file('../assets/app/serializers/base_serializer.rb', 'app/serializers/base_serializer.rb')
+  end
+
+  def add_image_handling_heroku_setup
+    append_to_file(
+      '.buildpacks',
+      <<~HERE
+        https://github.com/heroku/heroku-buildpack-apt
+        https://github.com/brandoncc/heroku-buildpack-vips
+      HERE
+    )
+    copy_file('../assets/Aptfile', 'Aptfile')
   end
 
   def common_setup


### PR DESCRIPTION
### General
This PR adds come things to facilitate image processing and handling in our projects, aimed at decreasing image loading times and improving loading experience. This is done mainly with the following elements:

-  Size derivatives: when uploading an image as an attachment of some model, we are generating three different sizes for that image. If we use an appropriate size for each part the image is used we could decrease the weigth of the payload the frontend has to render
- Webp derivatives: generally lower weight compared to a jpg or png alternative, without big quality sacrifice. They're not 100% supported by browsers, so jpg alternatives are also included
- [Blurhash](https://blurha.sh/): it's a string code generated from an image. The frontend decodes it and paints it in a `<canvas>` element very fast. It's used while an image is being loaded

### Details
The following was implemented as a part of the `file_storage` recipe when choosing `shrine`:
- `CoverImageUploader`:
  - Inherits from `ImageUploader`
  - Generates derivatives of three sizes, each with a `jpg` and `webp` variant
  - In addition to the predefined derivatives, a [derivation endpoint](https://shrinerb.com/docs/plugins/derivation_endpoint#docsNav) is mounted. This allows generation of ``urls with arbitrary sizes
  - The derivation endpoint is used to define a [default_url](https://shrinerb.com/docs/plugins/default_url#docsNav) for derivatives. This means that if, for any reason, an image doesn't have their predefined derivatives, when asking for their url, a url will be generated with the endpoint
  - Generates the blurhash code
    - Avoids generating it for derivatives, only main files
    - Before decoding it resizes the image, for a faster result that doesn't sacrifice much quality
    - `Blurhash.decode` requires an array of pixels in the `rgb` format, but `vips` was returning `rgba`, so the alpha byte is removed
- Attachment promotion (when the attachment goes from `cache` store to final storage) and derivatives creation is done in a background job, to not slow down uploads. default_url is particularly helpful with this
- `ImageHandlingAttributes` serializer concern and `BaseSerializer`. Only added if selected api rest. Concern adds `add_image_handling_attributes` that adds an `attributes` to the serializer with the name of the attachment and urls for chosen derivatives. Also adds a `<attachment_name>_blurhash` attributes
- `ImageHandlingUtilities` shrine plugin. It adds 3 class methods and 4 instance methods to models that use an Uploader that includes this plugin. Most of the methods are useful when making changes in derivatives and/or metadata, to backfill previus attachments. It's used in `CoverImageUploader`. Let's say the attachment's name is `image`, the methods are:
  - `image_blurhash`: returns blurhash from metadata. User in serializer
  - `generate_image_derivatives`: It generates all derivatives defined in Uploader. If file already had derivatives, it replaces them with newly generated ones. Associated class method: `generate_all_image_derivatives`
  - `generate_image_metadata`: refreshes all metadata for attachment. Associated class method: `generate_all_image_metadata`
  - `generate_image_derivatives_and_metadata`: does both previous things. Useful because it does so opening the file only once. Associated class method: `generate_all_image_derivatives_and_metadata`
Class methods are the same as their instance counterparts, but for collections. They also allow error handling on an individual record by passing a block to handle each error. If no block is given, attachments that throw errors are ignored and the iteration continues

### Questions for reviewers
- Should I add comments to some files (like image_handling_attributes, or cover_image_uploader) explaining some things?
- Are `small`, `medium`, `large` ok? Or are `sm`, `md`, `lg` better?