### PR TITLE
feat(cli-create): include platanus options if `platanus-config` is in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Features
   - Update power api gem to use v2.0.0. Install "internal" API mode [#394](https://github.com/platanus/potassium/pull/394)
   - Updates Webpacker to Shakapacker, upgrading Vue and TailwindCSS to their latest versions [#395](https://github.com/platanus/potassium/pull/395)
   - Add some image handling and processing in shrine file storage option [#398](https://github.com/platanus/potassium/pull/398)
+  - Include `--platanus-config` option to skip most of the instalation options [#399](https://github.com/platanus/potassium/pull/399).
 ## 6.5.0
 
 Features

--- a/README.md
+++ b/README.md
@@ -21,6 +21,34 @@ Use the `potassium create` command to create a new project:
 > 2. If you feel that it's too slow, you may need to update rubygems: `gem update --system`.
 > 3. Potassium uses node under the hood, so a check will also be performed to ensure you are running the supported version.
 
+#### Platanus Configutarion
+
+In case you want to use the Platanus Configuration you should use the following command:
+
+    $ potassium create <project-name> --platanus-config
+
+This will create a project with the following configuration:
+  1. `database`: `'postgresql'`
+  2. `local`: `'es-CL'`
+  3. `email_service`: `'sendgrid'`
+  4. `devise`: `true`
+  5. `devise-user-model`: `true`
+  6. `admin`: `true`
+  7. `vue_admin`: `true`
+  8. `pundit`: `true`
+  9. `api`: `'rest'`
+  10. `storage`: `'shrine'`
+  11. `heroku`: `true`
+  12. `background_processor`: `true`
+  13. `draper`: `true`
+  14. `schedule`: `true`
+  15. `sentry`: `true`
+  16. `front_end`: `'vue'`
+  17. `google_tag_manager`: `true`
+  18. `test`: `true`
+  19. `spring`: `true`
+
+The remaining question will be asked as usual.
 ### Adding recipes to an existing project
 
 Use the `potassium install` command to add a recipe to a project:

--- a/lib/potassium/cli/commands/create.rb
+++ b/lib/potassium/cli/commands/create.rb
@@ -12,12 +12,14 @@ module Potassium::CLI
     c.action do |_global_options, options, _args|
       require 'potassium/newest_version_ensurer'
       require 'potassium/node_version_ensurer'
+      require 'potassium/platanus_config'
       require 'potassium/generators/application'
       require 'potassium/template_finder'
 
       begin
         Potassium::NewestVersionEnsurer.new.ensure! if options['version-check']
         Potassium::NodeVersionEnsurer.new.ensure! if options['node-version-check']
+        options = Potassium::PlatanusConfig.new(options).generate! if options['platanus-config']
         template_finder = Potassium::TemplateFinder.new
         template = template_finder.default_template
         template.cli_options = options

--- a/lib/potassium/cli_options.rb
+++ b/lib/potassium/cli_options.rb
@@ -200,6 +200,14 @@ module Potassium::CliOptions # rubocop:disable Metrics/ModuleLength
       negatable: true,
       default_value: true,
       default_test_value: false
+    },
+    {
+      type: :switch,
+      name: 'platanus-config',
+      desc: 'Wheter to use the Platanus configuration.',
+      negatable: true,
+      default_value: false,
+      default_test_value: false
     }
   ]
 
@@ -218,5 +226,9 @@ module Potassium::CliOptions # rubocop:disable Metrics/ModuleLength
       memo[opt.to_s] = opts[:default_value]
       memo
     end
+  end
+
+  def self.option_names
+    CREATE_OPTIONS.map { |option| option[:name] }.flatten.map(&:to_sym)
   end
 end

--- a/lib/potassium/platanus_config.rb
+++ b/lib/potassium/platanus_config.rb
@@ -1,0 +1,20 @@
+module Potassium
+  class PlatanusConfig
+    def initialize(options)
+      @options = options
+      @option_key_names = Potassium::CliOptions.option_names
+    end
+
+    def generate!
+      default_options = {
+        'db': 'postgresql', 'locale': 'es-CL', 'email_service': 'sendgrid', 'devise': true,
+        'devise-user-model': true, 'admin': true, 'vue_admin': true, 'pundit': true,
+        'api': 'rest', 'storage': 'shrine', 'heroku': true, 'background_processor': true,
+        'draper': true, 'schedule': true, 'sentry': true, 'front_end': 'vue',
+        'google_tag_manager': true, 'test': true, 'spring': true
+      }
+      default_options = default_options.filter { |key, _| @option_key_names.include?(key) }
+      @options.merge(default_options, default_options.stringify_keys)
+    end
+  end
+end


### PR DESCRIPTION
## Objective
Create an option to use the Platanus configuration when creating a new project.

## Description
- I created a new class that defines the options used and ensures that the keys are valid key names.