### PR TITLE
feat(coverage-recipe): add front end coverage for jest

### DIFF
--- a/lib/potassium/recipes/coverage.rb
+++ b/lib/potassium/recipes/coverage.rb
@@ -3,6 +3,10 @@ class Recipes::Coverage < Rails::AppBuilder
     load_gems
     configure_rails_helper
     append_to_file('.gitignore', "/coverage/*\n")
+    recipe = self
+    after(:setup_jest) do
+      recipe.configure_jest_coverage
+    end
   end
 
   def installed?
@@ -11,6 +15,14 @@ class Recipes::Coverage < Rails::AppBuilder
 
   def install
     create
+  end
+
+  def configure_jest_coverage
+    json_file = File.read(Pathname.new("package.json"))
+    js_package = JSON.parse(json_file)
+    js_package = add_coverage_config(js_package)
+    json_string = JSON.pretty_generate(js_package)
+    create_file 'package.json', json_string, force: true
   end
 
   private
@@ -31,5 +43,19 @@ class Recipes::Coverage < Rails::AppBuilder
         "#{match}\nrequire 'simplecov_config'"
       end
     end
+  end
+
+  def add_coverage_config(js_package)
+    js_package['scripts']['test:changes'] = 'jest --changedSince=master'
+    js_package['jest'] = js_package['jest'].merge(coverage_defaults)
+    js_package
+  end
+
+  def coverage_defaults
+    {
+      collectCoverage: true,
+      collectCoverageFrom: ['**/*.{js,ts,vue}', '!**/node_modules/**'],
+      coverageReporters: ['text']
+    }
   end
 end

--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -156,10 +156,11 @@ class Recipes::FrontEnd < Rails::AppBuilder
     copy_file '../assets/app/javascript/components/app.vue', 'app/javascript/components/app.vue'
     copy_file '../assets/app/javascript/types/vue.d.ts', 'app/javascript/types/vue.d.ts'
     setup_vue_with_compiler_build
-    setup_jest
-    if get(:api) == :graphql
-      setup_apollo
+    recipe = self
+    run_action(:setup_jest) do
+      recipe.setup_jest
     end
+    setup_apollo if get(:api) == :graphql
   end
 
   private

--- a/spec/features/coverage_spec.rb
+++ b/spec/features/coverage_spec.rb
@@ -23,4 +23,16 @@ RSpec.describe "Coverage" do
     content = IO.read("#{project_path}/spec/simplecov_config.rb")
     expect(content).to include("SimpleCov.start 'rails'")
   end
+
+  context "with vue" do
+    before(:all) do
+      remove_project_directory
+      create_dummy_project("front_end" => "vue")
+    end
+
+    it "adds jest coverage configuration" do
+      node_modules_file = IO.read("#{project_path}/package.json")
+      expect(node_modules_file).to include('"collectCoverage": true')
+    end
+  end
 end


### PR DESCRIPTION
# Context
Potassium uses Jest for testing frontend code when using Vue. Jest provides some options to report test coverage. 

# Changes
Change the `coverage` recipe to add the necessary setup for Jest test coverage (if Jest is used). It modifies the existing `package.json` to add the coverage configuration.