### PR TITLE
feat(recipe): add rubocop-platanus to recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features
   - Updates Webpacker to Shakapacker, upgrading Vue and TailwindCSS to their latest versions [#395](https://github.com/platanus/potassium/pull/395)
   - Add some image handling and processing in shrine file storage option [#398](https://github.com/platanus/potassium/pull/398)
   - Include `--platanus-config` option to skip most of the instalation options [#399](https://github.com/platanus/potassium/pull/399).
+  - Add [`rubocop-platanus`](https://github.com/platanus/rubocop-platanus) gem for linting platanus' best practices [#402](https://github.com/platanus/potassium/pull/402).
 ## 6.5.0
 
 Features

--- a/lib/potassium/assets/.rubocop.yml
+++ b/lib/potassium/assets/.rubocop.yml
@@ -2,6 +2,7 @@ require:
   - rubocop-rspec
   - rubocop-rails
   - rubocop-performance
+  - rubocop-platanus
 AllCops:
   Exclude:
   - "vendor/**/*"

--- a/lib/potassium/recipes/style.rb
+++ b/lib/potassium/recipes/style.rb
@@ -17,6 +17,7 @@ class Recipes::Style < Rails::AppBuilder
       gather_gem 'rubocop-performance'
       gather_gem 'rubocop-rails'
       gather_gem 'rubocop-rspec', Potassium::RUBOCOP_RSPEC_VERSION
+      gather_gem 'rubocop-platanus'
     end
 
     after(:webpacker_install) do


### PR DESCRIPTION
# Contexto

En Platanus es un desafío grande transmitir las decisiones que vamos tomando en relación a estándares y buenas prácticas de desarrollo. Por ej: si empezamos a usar jobs en vez de comandos, ¿cómo hacemos que este cambio se empiece a aplicar en todos los proyectos? o si está prohibido usar una gema x, ¿cómo le avisamos a la gente que use una alternativa?

Basado en esta [investigación](https://github.com/593f4e45720245a1b35a58a70592f9c2?p=e8d9b39c29b44366b835c84eacbc9c2f), descubrimos que es factible transmitir esta información usando reglas custom de Rubocop.

Ya se creó la gema [rubocop-platanus](https://github.com/platanus/rubocop-platanus) como una extension de rubocop con estas reglas custom.

# Que se esta haciendo

Se agrega la gema rubocop-platanus y su configuración al recipe de nuevos proyectos.