### PR TITLE
Feat/frontend test coverage pr comments

### DIFF
--- a/lib/potassium/assets/.circleci/config.yml.erb
+++ b/lib/potassium/assets/.circleci/config.yml.erb
@@ -125,7 +125,10 @@ jobs:
       <%- if selected?(:front_end, :vue) -%>
       - run:
           name: Run jest
-          command: yarn run test
+          command: |
+            yarn run test > coverage/input_jest.txt
+            ./node_modules/.bin/format-coverage coverage/input_jest.txt coverage/output_jest.txt /home/circleci/project/app/javascript
+            cat coverage/output_jest.txt | ./bin/reviewdog -reporter=github-pr-review -efm="%f:%l:%c: %m"
       <%- end -%>
 
       - store_test_results:

--- a/lib/potassium/recipes/coverage.rb
+++ b/lib/potassium/recipes/coverage.rb
@@ -6,6 +6,7 @@ class Recipes::Coverage < Rails::AppBuilder
     recipe = self
     after(:setup_jest) do
       recipe.configure_jest_coverage
+      recipe.setup_jest_text_formatter
     end
   end
 
@@ -23,6 +24,10 @@ class Recipes::Coverage < Rails::AppBuilder
     js_package = add_coverage_config(js_package)
     json_string = JSON.pretty_generate(js_package)
     create_file 'package.json', json_string, force: true
+  end
+
+  def setup_jest_text_formatter
+    run "bin/yarn add jest-text-formatter@1.0.2 --dev"
   end
 
   private

--- a/spec/features/coverage_spec.rb
+++ b/spec/features/coverage_spec.rb
@@ -25,14 +25,19 @@ RSpec.describe "Coverage" do
   end
 
   context "with vue" do
+    let(:node_modules_file) { IO.read("#{project_path}/package.json") }
+
     before(:all) do
       remove_project_directory
       create_dummy_project("front_end" => "vue")
     end
 
     it "adds jest coverage configuration" do
-      node_modules_file = IO.read("#{project_path}/package.json")
       expect(node_modules_file).to include('"collectCoverage": true')
+    end
+
+    it "adds jest text formatter package" do
+      expect(node_modules_file).to include('jest-text-formatter')
     end
   end
 end


### PR DESCRIPTION
# Context

PR #387 added support for Reviewdog comments in Github PRs depending on back end testing coverage. This PR adds support for front end testing coverage comments.

# Changes

- Add `jest-text-formatter` package to the generated project dev dependencies. This library was created to format Jest test output to a readable format by Reviewdog.
- Add the formatting and Reviewdog call to Circle CI's "Run jest" command.

<img width="944" alt="image" src="https://user-images.githubusercontent.com/37163115/171948635-ffba4e83-aa48-49bf-bf5f-8968ae35f8f0.png">
