### PR TITLE
fix(circleci): fix tsc check

### DIFF
--- a/lib/potassium/assets/.circleci/config.yml.erb
+++ b/lib/potassium/assets/.circleci/config.yml.erb
@@ -168,15 +168,13 @@ jobs:
           name: Run tsc
           shell: /bin/bash
           command: |
-            cat tmp/files_to_lint | grep -E '.+\.(ts)$' | xargs yarn run tsc --noEmit ./app/javascript/types/*.d.ts  \
-            | ./bin/reviewdog -reporter=github-pr-review -f=tsc
+            yarn run tsc --noEmit | ./bin/reviewdog -reporter=github-pr-review -f=tsc
 
       - run:
           name: Run vue-tsc
           shell: /bin/bash
           command: |
-            cat tmp/files_to_lint | grep -E '.+\.(vue)$' | xargs yarn run vue-tsc --noEmit \
-            | ./bin/reviewdog -reporter=github-pr-review -f=tsc
+            yarn run vue-tsc --noEmit | ./bin/reviewdog -reporter=github-pr-review -f=tsc
 
       - run:
           name: Run stylelint


### PR DESCRIPTION
tsc (and vue-tsc) need to be run without a list of files, otherwise it can't find project-defined types. ReviewDog has its own diff filter so it should post only relevant comments.