### PR TITLE
fix(ci-config): run simplecov after unit and before system tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Fixes
+  - Fix monkeyci commenting because of uncovered lines when tests do exist [#416](https://github.com/platanus/potassium/pull/416)
+
 ## 6.6.0
 Features
   - Update power api gem to use v2.0.0. Install "internal" API mode [#394](https://github.com/platanus/potassium/pull/394)

--- a/lib/potassium/assets/.circleci/config.yml.erb
+++ b/lib/potassium/assets/.circleci/config.yml.erb
@@ -117,17 +117,17 @@ jobs:
             bundle exec rspec spec $RSPEC_FORMAT_ARGS $RSPEC_JUNIT_ARGS
 
       - run:
+          name: Run simplecov
+          shell: /bin/bash
+          command: |
+            cat coverage/coverage.txt | ./bin/reviewdog -reporter=github-pr-review -efm="%f:%l:%c: %m"
+
+      - run:
           name: Run RSpec system tests
           command: |
             RSPEC_JUNIT_ARGS="-r rspec_junit_formatter -f RspecJunitFormatter -o test_results/rspec-system.xml"
             RSPEC_FORMAT_ARGS="--tag type:system -f progress --no-color -p 10"
             bundle exec rspec spec $RSPEC_FORMAT_ARGS $RSPEC_JUNIT_ARGS
-
-      - run:
-          name: Run simplecov
-          shell: /bin/bash
-          command: |
-            cat coverage/coverage.txt | ./bin/reviewdog -reporter=github-pr-review -efm="%f:%l:%c: %m"
 
       <%- if selected?(:front_end, :vue) -%>
       - run:


### PR DESCRIPTION
### Contexto

Los proyectos generados recientemente con potassium tienen configurado para que monkeyci comente en los prs cuando alguno de los cambios introducidos en el pr no está testeado. Está pasando que el mono habitualmente se equivoca y comenta sobre líneas que si están testeadas, incluso en el mismo PR.

### Qué se esta haciendo

Se arregla este bug. El problema era que, el reporte de coverage que se generaba debido a los tests de sistema estaba sobreescribiendo al reporte de los unitarios. Es decir, reportaba cualquier cambio del pr que no estuviera cubierto por un test de sistema.
Para solucionarlo, simplemente se mueve el reporte de coverage de reviewdog para que ocurra después de los unitarios pero antes de los de sistema. Otra alternativa hubiera sido mergear ambos reportes, que está soportado por simplecov, pero en general vamos a querer asegurar coverage con test unitarios en primer lugar, y con eso en mente también están pensados los archivos que están considerados para el coverage.