### PR TITLE
fix(tsconfig): exclude mock files

### DIFF
--- a/lib/potassium/assets/tsconfig.json
+++ b/lib/potassium/assets/tsconfig.json
@@ -27,6 +27,7 @@
   ],
   "exclude": [
     "node_modules",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "**/*.mock.ts"
   ]
 }


### PR DESCRIPTION
### Context
In order to use mocks in front end tests, it is necesary to exclude them in the  `tsconfig.json` file. 

### What has been done:
The files ending in`.mock.ts` are excluded, so that when someone adds a mock file to the project the app keeps compiling. 

### In particular you have to check
The `tsconfig.json` file
