### PR TITLE
Frontend updates

### DIFF
--- a/lib/potassium/assets/.eslintrc.json
+++ b/lib/potassium/assets/.eslintrc.json
@@ -255,7 +255,7 @@
     "lines-around-comment": 0,
     "max-depth": [2, 4],
     "max-len": [2, 120, {
-      "ignorePattern": "^\\s.+class=\""
+      "ignorePattern": "^\\s.+class=|\\s.d=\""
     }],
     "max-nested-callbacks": [2, 4],
     "max-params": [1, 4],
@@ -287,7 +287,7 @@
     "no-new-object": 2,
     "no-plusplus": 0,
     "no-restricted-syntax": [2, "DebuggerStatement", "ForInStatement", "LabeledStatement", "WithStatement"],
-    "no-spaced-func": 2,
+    "no-spaced-func": 0,
     "no-ternary": 0,
     "no-trailing-spaces": 2,
     "no-underscore-dangle": [1],
@@ -346,14 +346,20 @@
     "vue/max-len": ["error", {
       "code": 120,
       "ignoreHTMLAttributeValues": true
+    }],
+    "tailwindcss/no-custom-classname": ["warn", {
+      "cssFiles": ["**/*.css", "!**/node_modules", "!**/.*", "!**/dist", "!**/build", "!**/vendor"]
     }]
   },
   "overrides": [
     {
-      "files": ["*.ts", "*.vue"],
-      "rules": {
-        "no-undef": "off"
-      }
+        "files": ["*.ts", "*.vue"],
+        "rules": {
+          "no-undef": "off",
+          "no-unused-vars": "off",
+          "no-spaced-func": "off",
+          "@typescript-eslint/no-unused-vars": "error"
+        }
     }
   ]
 }

--- a/lib/potassium/assets/app/javascript/api/index.ts
+++ b/lib/potassium/assets/app/javascript/api/index.ts
@@ -1,14 +1,14 @@
 import axios, { type AxiosRequestTransformer, type AxiosResponseTransformer } from 'axios';
-import convertKeys from '../utils/case-converter';
+import convertKeys, { type objectToConvert } from '../utils/case-converter';
 
 const api = axios.create({
   transformRequest: [
-    (data: any) => convertKeys(data, 'decamelize'),
+    (data: objectToConvert) => convertKeys(data, 'decamelize'),
     ...(axios.defaults.transformRequest as AxiosRequestTransformer[]),
   ],
   transformResponse: [
     ...(axios.defaults.transformResponse as AxiosResponseTransformer[]),
-    (data: any) => convertKeys(data, 'camelize'),
+    (data: objectToConvert) => convertKeys(data, 'camelize'),
   ],
 });
 

--- a/lib/potassium/assets/app/javascript/utils/case-converter.ts
+++ b/lib/potassium/assets/app/javascript/utils/case-converter.ts
@@ -3,7 +3,7 @@
 /* eslint-disable max-statements */
 import { camelize, decamelize } from 'humps';
 
-type objectToConvert = File | FormData | Blob | Record<string, unknown> | Array<objectToConvert>;
+export type objectToConvert = File | FormData | Blob | Record<string, unknown> | Array<objectToConvert>;
 
 function convertKeys(
   object: objectToConvert,

--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -7,6 +7,48 @@ class Recipes::FrontEnd < Rails::AppBuilder
   AUTOPREFIXER_VERSION = Potassium::AUTOPREFIXER_VERSION
   JEST_VERSION = Potassium::JEST_VERSION
 
+  DEPENDENCIES = {
+    api: [
+      "axios",
+      "humps",
+      "@types/humps"
+    ],
+    jest: [
+      "jest@#{JEST_VERSION}",
+      "@vue/vue3-jest@#{JEST_VERSION}",
+      "babel-jest@#{JEST_VERSION}",
+      "@vue/test-utils@#{VUE_TEST_UTILS_VERSION}",
+      "ts-jest@#{JEST_VERSION}",
+      "jest-environment-jsdom@#{JEST_VERSION}",
+      "@types/jest@#{JEST_VERSION}"
+    ],
+    tailwind: [
+      "css-loader",
+      "style-loader",
+      "mini-css-extract-plugin",
+      "@types/tailwindcss",
+      "css-minimizer-webpack-plugin",
+      "postcss@#{POSTCSS_VERSION}",
+      "postcss-loader",
+      "tailwindcss@#{TAILWINDCSS_VERSION}",
+      "autoprefixer@#{AUTOPREFIXER_VERSION}",
+      "sass",
+      "sass-loader",
+      "eslint-plugin-tailwindcss"
+    ],
+    typescript: [
+      "typescript",
+      "fork-ts-checker-webpack-plugin",
+      "ts-loader",
+      "@types/node"
+    ],
+    vue: [
+      "vue@#{VUE_VERSION}",
+      "vue-loader@#{VUE_LOADER_VERSION}",
+      "babel-preset-typescript-vue3"
+    ]
+  }
+
   def ask
     frameworks = {
       vue: "Vue",
@@ -73,7 +115,7 @@ class Recipes::FrontEnd < Rails::AppBuilder
   end
 
   def setup_typescript
-    run "bin/yarn add typescript fork-ts-checker-webpack-plugin ts-loader @types/node"
+    run "bin/yarn add #{DEPENDENCIES[:typescript].join(' ')}"
     copy_file '../assets/tsconfig.json', 'tsconfig.json'
   end
 
@@ -97,10 +139,7 @@ class Recipes::FrontEnd < Rails::AppBuilder
   end
 
   def setup_tailwind
-    run "bin/yarn add css-loader style-loader mini-css-extract-plugin @types/tailwindcss "\
-      "css-minimizer-webpack-plugin postcss@#{POSTCSS_VERSION} postcss-loader "\
-      "tailwindcss@#{TAILWINDCSS_VERSION} autoprefixer@#{AUTOPREFIXER_VERSION} sass sass-loader "\
-      "eslint-plugin-tailwindcss"
+    run "bin/yarn add #{DEPENDENCIES[:tailwind].join(' ')}"
     run "npx tailwindcss init -p"
     setup_client_css
     remove_server_css_requires
@@ -108,10 +147,7 @@ class Recipes::FrontEnd < Rails::AppBuilder
   end
 
   def setup_jest
-    run "bin/yarn add jest@#{JEST_VERSION} @vue/vue3-jest@#{JEST_VERSION} "\
-    "babel-jest@#{JEST_VERSION} @vue/test-utils@#{VUE_TEST_UTILS_VERSION} ts-jest@#{JEST_VERSION} "\
-    "jest-environment-jsdom@#{JEST_VERSION} --dev"
-    run "bin/yarn add @types/jest@#{JEST_VERSION}"
+    run "bin/yarn add #{DEPENDENCIES[:jest].join(' ')} --dev"
     json_file = File.read(Pathname.new("package.json"))
     js_package = JSON.parse(json_file)
     js_package = js_package.merge(jest_config)
@@ -123,9 +159,7 @@ class Recipes::FrontEnd < Rails::AppBuilder
   end
 
   def setup_vue
-    run "bin/yarn add vue@#{VUE_VERSION} vue-loader@#{VUE_LOADER_VERSION} "\
-        "babel-preset-typescript-vue3 @types/humps"
-    run "bin/yarn add vue-tsc --dev"
+    run "bin/yarn add #{DEPENDENCIES[:vue].join(' ')}"
     gsub_file(
       'config/webpack/webpack.config.js',
       ' merge(typescriptConfig, cssConfig, jQueryConfig, webpackConfig);',
@@ -141,7 +175,7 @@ class Recipes::FrontEnd < Rails::AppBuilder
   end
 
   def setup_api_client
-    run "bin/yarn add axios humps"
+    run "bin/yarn add #{DEPENDENCIES[:api].join(' ')}"
     copy_file '../assets/app/javascript/api/index.ts', 'app/javascript/api/index.ts'
     copy_file '../assets/app/javascript/utils/case-converter.ts',
               'app/javascript/utils/case-converter.ts'

--- a/lib/potassium/recipes/style.rb
+++ b/lib/potassium/recipes/style.rb
@@ -25,7 +25,7 @@ class Recipes::Style < Rails::AppBuilder
         "@typescript-eslint/eslint-plugin  @types/jest @typescript-eslint/parser "\
         "eslint-plugin-jest eslint-plugin-platanus"
       if selected?(:front_end, :vue)
-        run 'yarn add --dev eslint-plugin-vue @vue/eslint-config-typescript'
+        run 'yarn add --dev eslint-plugin-vue @vue/eslint-config-typescript vue-tsc'
       end
     end
   end


### PR DESCRIPTION
- Agrega reglas override para evitar alertas que no son necesarias cuando se trabaja en archivos Vue con typescript
- Mueve todas las dependencies de NPM a un hash para que sea más fácil revisar y/o cambiar lo que se está instalando
- Agrega type a los datos procesados por `convertKeys`