### PR TITLE
feat(mok-example/FrontEndRecipe): add mock example for api index

### DIFF
--- a/lib/potassium/assets/app/javascript/api/__mocks__/index.mock.ts
+++ b/lib/potassium/assets/app/javascript/api/__mocks__/index.mock.ts
@@ -1,0 +1,3 @@
+const api = jest.fn();
+
+export default api;

--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -177,6 +177,8 @@ class Recipes::FrontEnd < Rails::AppBuilder
   def setup_api_client
     run "bin/yarn add #{DEPENDENCIES[:api].join(' ')}"
     copy_file '../assets/app/javascript/api/index.ts', 'app/javascript/api/index.ts'
+    copy_file '../assets/app/javascript/api/__mocks__/index.mock.ts',
+              'app/javascript/api/__mocks__/index.mock.ts'
     copy_file '../assets/app/javascript/utils/case-converter.ts',
               'app/javascript/utils/case-converter.ts'
   end

--- a/spec/features/front_end_spec.rb
+++ b/spec/features/front_end_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe "Front end" do
     remove_project_directory
   end
 
-  let(:application_css_path) { "#{project_path}/app/javascript/css/application.css" }
   let(:gemfile) { IO.read("#{project_path}/Gemfile") }
   let(:node_modules_file) { IO.read("#{project_path}/package.json") }
   let(:application_js_file) { IO.read("#{project_path}/app/javascript/application.js") }
   let(:layout_file) { IO.read("#{project_path}/app/views/layouts/application.html.erb") }
-  let(:application_css_file) { IO.read(application_css_path) }
+  let(:application_css_file) { IO.read("#{project_path}/app/javascript/css/application.css") }
   let(:tailwind_config_file) { IO.read("#{project_path}/tailwind.config.js") }
   let(:rails_css_file) { IO.read("#{project_path}/app/assets/stylesheets/application.css") }
+  let(:mock_example_file) { IO.read("#{project_path}/app/javascript/api/__mocks__/index.mock.ts") }
 
   it "creates a project without a front end framework" do
     remove_project_directory
@@ -71,6 +71,10 @@ RSpec.describe "Front end" do
     it 'includes correct packages for basic api client' do
       expect(node_modules_file).to include("\"axios\"")
       expect(node_modules_file).to include("\"humps\"")
+    end
+
+    it 'includes mock example' do
+      expect(mock_example_file).to include('jest.fn()')
     end
   end
 end


### PR DESCRIPTION
### Context
In a previous PR we excluded `.mock` files from the `tsconfig.json` . Now we want to add a very simple example of a mock

### What has been done
A mock example file for the `api/index.ts` was added

### In particular you have to check
- The example mok `index.mock.ts`
- The `frontend recipe` where this file was copied

