### PR TITLE
feat(sentry): replace sentry raven with sentry rails

### DIFF
--- a/lib/potassium/assets/config/sentry.rb.erb
+++ b/lib/potassium/assets/config/sentry.rb.erb
@@ -1,15 +1,7 @@
 if Rails.env.production?
-  Raven.configure do |config|
-    config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  Sentry.init do |config|
     <% if get(:heroku) %>
-    config.current_environment = Heroku.stage
+      config.environment = Heroku.stage
     <% end %>
-  end
-
-  # In case you want to group the events with different ids in the
-  module RackTimeoutExtensions
-    def raven_context
-      { fingerprint: ["{{ default }}", env["REQUEST_PATH"].gsub(/\d/, '')] }
-    end
   end
 end

--- a/lib/potassium/recipes/error_reporting.rb
+++ b/lib/potassium/recipes/error_reporting.rb
@@ -8,7 +8,7 @@ class Recipes::ErrorReporting < Rails::AppBuilder
 
   def create
     if selected?(:report_error)
-      gather_gem 'sentry-raven'
+      gather_gem 'sentry-rails'
       template '../assets/config/sentry.rb.erb', 'config/initializers/sentry.rb'
       append_to_file '.env.development', "SENTRY_DSN=\n"
       add_readme_section :internal_dependencies, :sentry
@@ -21,6 +21,6 @@ class Recipes::ErrorReporting < Rails::AppBuilder
   end
 
   def installed?
-    gem_exists?(/sentry-raven/) && file_exist?('config/initializers/sentry.rb')
+    gem_exists?(/sentry-rails/) && file_exist?('config/initializers/sentry.rb')
   end
 end

--- a/spec/features/error_reporting_spec.rb
+++ b/spec/features/error_reporting_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe "Error Reporting" do
   it "adds the Sentry gem to Gemfile" do
     gemfile_content = IO.read("#{project_path}/Gemfile")
 
-    expect(gemfile_content).to include("gem 'sentry-raven'")
+    expect(gemfile_content).to include("gem 'sentry-rails'")
   end
 
   it "creates the initializer" do
     initializer_content = IO.read("#{project_path}/config/initializers/sentry.rb")
 
-    expect(initializer_content).to include("Raven.configure")
+    expect(initializer_content).to include("Sentry.init")
   end
 
   it "adds the environment variable to .env.development" do


### PR DESCRIPTION
### Context
We are using` sentry-raven`  which is deprecated, so we want to upgrade to `sentry-rails` 💎 
​
### What has been done
The upgrade to `sentry-rails `according to the guide linked below.
​
#### In particular you have to check
The initializer `sentry.rb`.
​

-----------
#### Additional info (screenshots, links, sources, etc.)
- raven `sanitize_fields` is removed  from `sentry-ruby`
- sentry-ruby doesn't capture raven_context from exceptions anymore. 

https://docs.sentry.io/platforms/ruby/migration/

Builder card: https://www.notion.so/platanus/Upgrade-de-sentry-raven-a-sentry-rails-a946a8fa22974bafaa372ac716668f5c
