### PR TITLE
Feat/csrf token

### DIFF
--- a/lib/potassium/assets/app/javascript/api/index.ts
+++ b/lib/potassium/assets/app/javascript/api/index.ts
@@ -1,5 +1,6 @@
 import axios, { type AxiosRequestTransformer, type AxiosResponseTransformer } from 'axios';
 import convertKeys, { type objectToConvert } from '../utils/case-converter';
+import csrfToken from '../utils/csrf-token';
 
 const api = axios.create({
   transformRequest: [
@@ -10,6 +11,11 @@ const api = axios.create({
     ...(axios.defaults.transformResponse as AxiosResponseTransformer[]),
     (data: objectToConvert) => convertKeys(data, 'camelize'),
   ],
+  headers: {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+    'X-CSRF-Token': csrfToken(),
+  },
 });
 
 export default api;

--- a/lib/potassium/assets/app/javascript/utils/csrf-token.ts
+++ b/lib/potassium/assets/app/javascript/utils/csrf-token.ts
@@ -1,0 +1,9 @@
+// From: https://github.com/rails/rails/blob/main/actionview/app/javascript/rails-ujs/utils/csrf.js
+function csrfToken() {
+  const meta = document.querySelector('meta[name=csrf-token]');
+  const token = meta && meta.getAttribute('content');
+
+  return token ?? false;
+}
+
+export default csrfToken;

--- a/lib/potassium/recipes/front_end.rb
+++ b/lib/potassium/recipes/front_end.rb
@@ -181,6 +181,8 @@ class Recipes::FrontEnd < Rails::AppBuilder
               'app/javascript/api/__mocks__/index.mock.ts'
     copy_file '../assets/app/javascript/utils/case-converter.ts',
               'app/javascript/utils/case-converter.ts'
+    copy_file '../assets/app/javascript/utils/csrf-token.ts',
+              'app/javascript/utils/csrf-token.ts'
   end
 
   private

--- a/spec/features/front_end_spec.rb
+++ b/spec/features/front_end_spec.rb
@@ -6,14 +6,21 @@ RSpec.describe "Front end" do
     remove_project_directory
   end
 
-  let(:gemfile) { IO.read("#{project_path}/Gemfile") }
-  let(:node_modules_file) { IO.read("#{project_path}/package.json") }
-  let(:application_js_file) { IO.read("#{project_path}/app/javascript/application.js") }
-  let(:layout_file) { IO.read("#{project_path}/app/views/layouts/application.html.erb") }
-  let(:application_css_file) { IO.read("#{project_path}/app/javascript/css/application.css") }
-  let(:tailwind_config_file) { IO.read("#{project_path}/tailwind.config.js") }
-  let(:rails_css_file) { IO.read("#{project_path}/app/assets/stylesheets/application.css") }
-  let(:mock_example_file) { IO.read("#{project_path}/app/javascript/api/__mocks__/index.mock.ts") }
+  def read_file(file_path)
+    IO.read("#{project_path}/#{file_path}")
+  end
+
+  let(:gemfile) { read_file('Gemfile') }
+  let(:node_modules_file) { read_file('package.json') }
+  let(:application_js_file) { read_file('app/javascript/application.js') }
+  let(:layout_file) { read_file('app/views/layouts/application.html.erb') }
+  let(:application_css_file) { read_file('app/javascript/css/application.css') }
+  let(:tailwind_config_file) { read_file('tailwind.config.js') }
+  let(:rails_css_file) { read_file('app/assets/stylesheets/application.css') }
+  let(:api_index_file) { read_file('app/javascript/api/index.ts') }
+  let(:case_converter_file) { read_file('app/javascript/utils/case-converter.ts') }
+  let(:csrf_token_file) { read_file('app/javascript/utils/csrf-token.ts') }
+  let(:mock_example_file) { read_file('app/javascript/api/__mocks__/index.mock.ts') }
 
   it "creates a project without a front end framework" do
     remove_project_directory
@@ -71,6 +78,12 @@ RSpec.describe "Front end" do
     it 'includes correct packages for basic api client' do
       expect(node_modules_file).to include("\"axios\"")
       expect(node_modules_file).to include("\"humps\"")
+    end
+
+    it 'includes api client files' do
+      expect(api_index_file).to include('axios.create')
+      expect(case_converter_file).to include('humps')
+      expect(csrf_token_file).to include('meta[name=csrf-token]')
     end
 
     it 'includes mock example' do


### PR DESCRIPTION
### Context
We want to add csfr token in the headers of the api client requests  in potassium without using the @rails/ujs dependency.
​
### What has been done
The util csrf token was added and used in the api index file. 

**Commit by commit**
- Adds the csrf token util
- Uses the new file in the api index and ​includes it in the recipe
- 
#### In particular you have to check
The new  util `csrf-token` and the adittion in the frontend recipe
​

-----------
#### Additional info (screenshots, links, sources, etc.)