### PR TITLE
Refactor/default exports rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Features
   - Removes enumerize in favor of built-in enums [#428](https://github.com/platanus/potassium/pull/428)
+  - Add linter rule to enforce the use of named exports [#427](https://github.com/platanus/potassium/pull/427)
 
 ## 6.7.0
 

--- a/lib/potassium/assets/.eslintrc.json
+++ b/lib/potassium/assets/.eslintrc.json
@@ -209,7 +209,7 @@
       "newlines-between": "never"
     }],
     "import/newline-after-import": 2,
-    "import/prefer-default-export": 2,
+    "import/no-default-export": 2,
     "array-bracket-spacing": [2, "never"],
     "block-spacing": [2, "always"],
     "brace-style": [2, "1tbs", {

--- a/lib/potassium/assets/app/javascript/api/__mocks__/index.mock.ts
+++ b/lib/potassium/assets/app/javascript/api/__mocks__/index.mock.ts
@@ -1,3 +1,3 @@
 const api = jest.fn();
 
-export default api;
+export { api };

--- a/lib/potassium/assets/app/javascript/api/index.ts
+++ b/lib/potassium/assets/app/javascript/api/index.ts
@@ -1,6 +1,6 @@
 import axios, { type AxiosRequestTransformer, type AxiosResponseTransformer } from 'axios';
-import convertKeys, { type objectToConvert } from '../utils/case-converter';
-import csrfToken from '../utils/csrf-token';
+import { convertKeys, type objectToConvert } from '../utils/case-converter';
+import { csrfToken } from '../utils/csrf-token';
 
 const api = axios.create({
   transformRequest: [
@@ -18,44 +18,46 @@ const api = axios.create({
   },
 });
 
-export default api;
+export { api };
 
 /*
 // Example to use the api object in the path ´app/javascript/api/users.ts´
 
-import api from './index';
+import { api } from './index';
 
-export default {
-  index() {
-    const path = '/api/internal/users';
+function index() {
+  const path = '/api/internal/users';
 
-    return api({
-      method: 'get',
-      url: path,
-    });
-  },
-  create(data: Partial<User>) {
-    const path = '/api/internal/users';
+  return api({
+    method: 'get',
+    url: path,
+  });
+}
 
-    return api({
-      method: 'post',
-      url: path,
-      data: {
-        user: data,
-      },
-    });
-  },
-  update(data: Partial<User>) {
-    const path = `/api/internal/users/${data.id}`;
+function create(data: Partial<User>) {
+  const path = '/api/internal/users';
 
-    return api({
-      method: 'put',
-      url: path,
-      data: {
-        user: data,
-      },
-    });
-  },
-};
+  return api({
+    method: 'post',
+    url: path,
+    data: {
+      user: data,
+    },
+  });
+}
+
+function update(data: Partial<User>) {
+  const path = `/api/internal/users/${data.id}`;
+
+  return api({
+    method: 'put',
+    url: path,
+    data: {
+      user: data,
+    },
+  });
+}
+
+export { index, create, update };
 
 */

--- a/lib/potassium/assets/app/javascript/types/vue.d.ts
+++ b/lib/potassium/assets/app/javascript/types/vue.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-default-export */
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
   const component: DefineComponent<{}, {}, any>

--- a/lib/potassium/assets/app/javascript/utils/case-converter.ts
+++ b/lib/potassium/assets/app/javascript/utils/case-converter.ts
@@ -36,4 +36,4 @@ function convertKeys(
   return object;
 }
 
-export default convertKeys;
+export { convertKeys };

--- a/lib/potassium/assets/app/javascript/utils/csrf-token.ts
+++ b/lib/potassium/assets/app/javascript/utils/csrf-token.ts
@@ -6,4 +6,4 @@ function csrfToken() {
   return token ?? false;
 }
 
-export default csrfToken;
+export { csrfToken };


### PR DESCRIPTION
## Context
​Currently, the `import/prefer-default-export` rule from [eslint-plugin-import](https://github.com/import-js/eslint-plugin-import) is being used. This rules enforces a default (versus named) export when only one thing is exported from a module.

There are good arguments to use named exports instead of default exports, like the ones explained in [this document](https://gitlab.com/gitlab-org/frontend/rfcs/-/issues/20#advantages-of-switching-patterns) or in [this post](https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/).

## What has been done
Summary: the prefer default export requirement has been inverted, now all exports must be named.

Commits:
1. Replace the `import/prefer-default-export` rule with `import/no-default-export` in the `.eslintrc.json` file.
2. Disable the new rule in the vue component type definition.
3. Replace all default exports with named exports.
4. Add this change to the changelog

### In particular you have to check
The rule disabling in the vue component type definition. Maybe I should ignore the rule in a different way, like using overrides in the `.eslintrc.json` file.

### Additional info (screenshots, links, sources, etc.)
