### PR TITLE
feat(application-template): remove enumerize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+Features
+  - Removes enumerize in favor of built-in enums [#428](https://github.com/platanus/potassium/pull/428)
+
 ## 6.7.0
 
 Features

--- a/lib/potassium/templates/application.rb
+++ b/lib/potassium/templates/application.rb
@@ -12,10 +12,6 @@ run_action(:cleaning) do
   clean_gemfile
 end
 
-run_action(:add_utils) do
-  gather_gem("enumerize")
-end
-
 run_action(:asking) do
   ask :database
   ask :devise


### PR DESCRIPTION
Se saca enumerize, de hace rato se usan los enums built in en Rails