### PR TITLE
feat(assets-rubocop-yml): enable new rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 Features
   - Removes enumerize in favor of built-in enums [#428](https://github.com/platanus/potassium/pull/428)
   - Add linter rule to enforce the use of named exports [#427](https://github.com/platanus/potassium/pull/427)
+  - Enable new rubocop rules [#429](https://github.com/platanus/potassium/pull/429)
+    <details>
+      <summary>See rules</summary>
+
+      - [Rails/Delegate](https://docs.rubocop.org/rubocop-rails/2.17/cops_rails.html#railsdelegate)
+      - [Rails/I18nLocaleAssignment](https://docs.rubocop.org/rubocop-rails/2.17/cops_rails.html#railsi18nlocaleassignment)
+      - [Rails/WhereEquals](https://docs.rubocop.org/rubocop-rails/2.17/cops_rails.html#railswhereequals)
+      - [Rails/WhereNot](https://docs.rubocop.org/rubocop-rails/2.17/cops_rails.html#railswherenot)
+      - [Rails/RedundantPresenceValidationOnBelongsTo](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsredundantpresencevalidationonbelongsto)
+      - [Layout/ClassStructure](https://docs.rubocop.org/rubocop/1.24/cops_layout.html#layoutclassstructure)
+    </details>
 
 ## 6.7.0
 

--- a/lib/potassium/assets/.rubocop.yml
+++ b/lib/potassium/assets/.rubocop.yml
@@ -282,6 +282,59 @@ Style/SymbolArray:
 Layout/ExtraSpacing:
   Description: Do not use unnecessary spacing.
   Enabled: false
+Layout/ClassStructure:
+  Enabled: true
+  Categories:
+    validation:
+      - validate
+      - validates
+    association:
+      - belongs_to
+      - has_one
+      - has_many
+      - has_and_belongs_to_many
+    attribute_macros:
+      - attribute
+      - attr_accessor
+      - attr_reader
+      - attr_writer
+    callbacks:
+      - before_validation
+      - after_validation
+      - before_save
+      - before_create
+      - after_create
+      - after_save
+      - after_commit
+      - after_create_commit
+    other_macros:
+      - devise
+      - acts_as_token_authenticatable
+      - accepts_nested_attributes_for
+      - humanize
+      - monetize
+    scope:
+      - scope
+      - pg_search_scope
+  ExpectedOrder:
+    - module_inclusion
+    - constants
+    - public_attribute_macros
+    - association
+    - validation
+    - enum
+    - aasm
+    - scope
+    - public_delegate
+    - other_macros
+    - class_methods
+    - initializer
+    - public_methods
+    - protected_attribute_macros
+    - protected_methods
+    - private_attribute_macros
+    - private_delegate
+    - private_methods
 Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   Enabled: false
@@ -498,7 +551,15 @@ Lint/StructNewOverride:
   Enabled: true
 Rails/Delegate:
   Description: Prefer delegate method for delegations.
-  Enabled: false
+  Enabled: true
+Rails/I18nLocaleAssignment:
+  Enabled: true
+Rails/WhereEquals:
+  Enabled: true
+Rails/WhereNot:
+  Enabled: true
+Rails/RedundantPresenceValidationOnBelongsTo:
+  Enabled: true
 Performance/RedundantBlockCall:
   Description: Use `yield` instead of `block.call`.
   Reference: https://github.com/JuanitoFatas/fast-ruby#proccall-vs-yield-code


### PR DESCRIPTION
Se habilitan algunas reglas nuevas en rubocop:

- [Rails/Delegate](https://docs.rubocop.org/rubocop-rails/2.17/cops_rails.html#railsdelegate)
- [Rails/I18nLocaleAssignment](https://docs.rubocop.org/rubocop-rails/2.17/cops_rails.html#railsi18nlocaleassignment)
- [Rails/WhereEquals](https://docs.rubocop.org/rubocop-rails/2.17/cops_rails.html#railswhereequals)
- [Rails/WhereNot](https://docs.rubocop.org/rubocop-rails/2.17/cops_rails.html#railswherenot)
- [Rails/RedundantPresenceValidationOnBelongsTo](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsredundantpresencevalidationonbelongsto)
- [Layout/ClassStructure](https://docs.rubocop.org/rubocop/1.24/cops_layout.html#layoutclassstructure)

Esta última me gustaría que se revise particularmente. Se define un orden en el que van los distintos elementos de una clase, pensado principalmente para el orden en modelos. El orden es una combinación del ejemplo que sale en los docs y lo que vi en platanus revisando modelos. Ahí díganme si les hace sentido o cambiarían algo.
El cop define una lista en `ExpectedOrder` que puede tener: grupos definidos en `Categories`, macros sueltas (`enum`, `aasm`), algunas cosas definidas de antemano en algún lado que rubocop entiende (`constants`, `methods`), y cosas anteriores con prefijo de nivel de privacidad.

Al recibir una clase con el orden dado vuelta lanza los siguientes errores:
<img width="1048" alt="image" src="https://user-images.githubusercontent.com/12057523/210823481-ecc52325-464d-4001-b96c-9c1d5b2e39cf.png">

Y al correr el autocorrect queda así:
<img width="333" alt="image" src="https://user-images.githubusercontent.com/12057523/210823728-4d051bdd-d517-4514-ac0d-32a30013eb7d.png">
Los espaciados quizás es mejorable, pero hace harto de la pega
