### PR TITLE
Feat/run rubocop on created project

### DIFF
--- a/lib/potassium/helpers/rubocop-helpers.rb
+++ b/lib/potassium/helpers/rubocop-helpers.rb
@@ -1,15 +1,7 @@
 module RubocopHelpers
-  def rubocop_revision
-    fix_environments
-  end
-
-  private
-
-  def fix_environments
-    # Style problem in Rails 5 production environments
-    file_name = "config/environments/production.rb"
-    production = File.read(file_name)
-    production.gsub!("config.log_tags = [ :request_id ]", "config.log_tags = [:request_id]")
-    File.open(file_name, "w") { |file| file.write(production) }
+  def run_rubocop
+    options, paths = RuboCop::Options.new.parse(["-A"])
+    runner = RuboCop::Runner.new(options, RuboCop::ConfigStore.new)
+    runner.run(paths)
   end
 end

--- a/lib/potassium/templates/application.rb
+++ b/lib/potassium/templates/application.rb
@@ -4,10 +4,6 @@ set :titleized_app_name, get(:app_name).titleize
 set :underscorized_app_name, get(:app_name).underscore
 set :dasherized_app_name, get(:app_name).dasherize
 
-run_action(:after_create_rails) do
-  rubocop_revision
-end
-
 run_action(:cleaning) do
   clean_gemfile
 end
@@ -91,4 +87,8 @@ end
 run_action(:database_creation) do
   run "bundle exec rails db:create db:migrate"
   run "RACK_ENV=test bundle exec rails db:create db:migrate"
+end
+
+run_action(:rubocop_revision) do
+  run_rubocop
 end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -9,14 +9,8 @@ RSpec.describe "A new project" do
   end
 
   it "is correctly bundled" do
-    expect { on_project { `bundle exec rails -v` } }.to_not output.to_stderr
+    expect { on_project { `bundle exec rails -v` } }.not_to output.to_stderr
   end
-
-  # it "is a valid rubocop project" do
-    # on_project do
-    #   expect(run_rubocop).to eq(true)
-    # end
-  # end
 
   it "configures postgresql" do
     database_config_file = IO.read("#{project_path}/config/database.yml")

--- a/spec/support/potassium_test_helpers.rb
+++ b/spec/support/potassium_test_helpers.rb
@@ -97,10 +97,4 @@ module PotassiumTestHelpers
   def run_command(command)
     system(command)
   end
-
-  def run_rubocop
-    options, paths = RuboCop::Options.new.parse(["."])
-    runner = RuboCop::Runner.new(options, RuboCop::ConfigStore.new)
-    runner.run(paths)
-  end
 end


### PR DESCRIPTION
Agrega que se corra rubocop y corrija los errores que encuentre luego de crear el proyecto. Aproveché de borrar unos trositos de código que tenían que ver con rubocop y que no se estaban usando.