### PR TITLE
Ci fixes

### DIFF
--- a/lib/potassium/assets/.circleci/config.yml.erb
+++ b/lib/potassium/assets/.circleci/config.yml.erb
@@ -140,9 +140,7 @@ jobs:
       - run:
           name: Run vitest
           command: |
-            yarn run test > coverage/input_vitest.txt
-            ./node_modules/.bin/format-coverage coverage/input_vitest.txt coverage/output_vitest.txt /home/circleci/project/app/frontend
-            cat coverage/output_vitest.txt | ./bin/reviewdog -reporter=github-pr-review -efm="%f:%l:%c: %m"
+            yarn run test
 
       - store_test_results:
           path: test_results

--- a/lib/potassium/assets/.circleci/config.yml.erb
+++ b/lib/potassium/assets/.circleci/config.yml.erb
@@ -122,7 +122,7 @@ jobs:
 
       - run:
           name: POST extracted data to nest
-          command: bin/rake "repo_analyzer:analyze[platanus/<%= get(:app_name) %>]"
+          command: bin/rake "repo_analyzer:analyze[platanus/<%= get(:github_repo_name) || get(:dasherized_app_name) %>]"
 
       - run:
           name: Run simplecov

--- a/lib/potassium/assets/.circleci/config.yml.erb
+++ b/lib/potassium/assets/.circleci/config.yml.erb
@@ -137,12 +137,12 @@ jobs:
             RSPEC_FORMAT_ARGS="--tag type:system -f progress --no-color -p 10"
             bundle exec rspec spec $RSPEC_FORMAT_ARGS $RSPEC_JUNIT_ARGS
 
-    - run:
-        name: Run vitest
-        command: |
-          yarn run test > coverage/input_vitest.txt
-          ./node_modules/.bin/format-coverage coverage/input_vitest.txt coverage/output_vitest.txt /home/circleci/project/app/frontend
-          cat coverage/output_vitest.txt | ./bin/reviewdog -reporter=github-pr-review -efm="%f:%l:%c: %m"
+      - run:
+          name: Run vitest
+          command: |
+            yarn run test > coverage/input_vitest.txt
+            ./node_modules/.bin/format-coverage coverage/input_vitest.txt coverage/output_vitest.txt /home/circleci/project/app/frontend
+            cat coverage/output_vitest.txt | ./bin/reviewdog -reporter=github-pr-review -efm="%f:%l:%c: %m"
 
       - store_test_results:
           path: test_results

--- a/lib/potassium/assets/.eslintrc.json
+++ b/lib/potassium/assets/.eslintrc.json
@@ -3,14 +3,14 @@
     "browser": true,
     "es2021": true,
     "node": true,
-    "jest/globals": true,
+    "vi": true,
     "vue/setup-compiler-macros": true
   },
   "parserOptions": {
     "ecmaVersion": 2020,
     "sourceType": "module"
   },
-  "plugins": ["import", "jest", "tailwindcss"],
+  "plugins": ["import", "tailwindcss"],
   "settings": {
     "import/resolver": {
       "node": {

--- a/lib/potassium/assets/app/frontend/api/__mocks__/index.mock.ts
+++ b/lib/potassium/assets/app/frontend/api/__mocks__/index.mock.ts
@@ -1,3 +1,3 @@
-const api = jest.fn();
+const api = vi.fn();
 
 export { api };

--- a/lib/potassium/assets/tsconfig.config.json
+++ b/lib/potassium/assets/tsconfig.config.json
@@ -3,6 +3,6 @@
   "include": ["vite.config.*", "vitest.config.*", "cypress.config.*", "playwright.config.*"],
   "compilerOptions": {
     "composite": true,
-    "types": ["node"]
+    "types": ["node", "vitest/globals"]
   }
 }

--- a/lib/potassium/recipes/coverage.rb
+++ b/lib/potassium/recipes/coverage.rb
@@ -18,7 +18,7 @@ class Recipes::Coverage < Rails::AppBuilder
   end
 
   def setup_coverage_dependencies
-    run "yarn add jest-text-formatter@1.0.2 c8 --dev"
+    run "yarn add c8 --dev"
   end
 
   private

--- a/lib/potassium/recipes/style.rb
+++ b/lib/potassium/recipes/style.rb
@@ -22,9 +22,9 @@ class Recipes::Style < Rails::AppBuilder
 
     after(:vite_install) do
       run "yarn add --dev stylelint eslint eslint-plugin-import "\
-        "@typescript-eslint/eslint-plugin  @types/jest @typescript-eslint/parser "\
-        "eslint-plugin-jest eslint-plugin-platanus eslint-plugin-vue "\
-        "@vue/eslint-config-typescript eslint-plugin-tailwindcss"
+        "@typescript-eslint/eslint-plugin @typescript-eslint/parser "\
+        "eslint-plugin-platanus eslint-plugin-vue @vue/eslint-config-typescript "\
+        "eslint-plugin-tailwindcss"
     end
   end
 

--- a/lib/potassium/templates/application.rb
+++ b/lib/potassium/templates/application.rb
@@ -32,7 +32,6 @@ run_action(:recipe_loading) do
   create :spring
   create :readme
   create :heroku
-  create :ci
   create :style
   create :puma
   create :env
@@ -67,6 +66,7 @@ run_action(:recipe_loading) do
   create :tzinfo
   create :script
   create :github
+  create :ci
   create :cleanup
   create :google_tag_manager
   create :mjml

--- a/spec/features/ci_spec.rb
+++ b/spec/features/ci_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe 'CI' do
     expect(ci_config).to include('cimg/ruby', 'cache', 'rspec', 'reviewdog')
   end
 
-  it "adds repo analyzer config" do
-    expect(ci_config).to include('bin/rake "repo_analyzer:analyze[platanus/dummy_app]"')
+  it "uses dasherized app name for repo analyzer" do
+    expect(ci_config).to include(
+      "repo_analyzer:analyze[platanus/#{PotassiumTestHelpers::APP_NAME.dasherize}]"
+    )
   end
 end

--- a/spec/features/coverage_spec.rb
+++ b/spec/features/coverage_spec.rb
@@ -36,9 +36,5 @@ RSpec.describe "Coverage" do
     it "adds vitest coverage configuration" do
       expect(vite_config).to include("provider: 'c8',")
     end
-
-    it "adds jest text formatter package" do
-      expect(node_modules_file).to include('jest-text-formatter')
-    end
   end
 end

--- a/spec/front_end_vite_spec.rb
+++ b/spec/front_end_vite_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Front end' do
   end
 
   it 'includes mock example' do
-    expect(mock_example_file).to include('jest.fn()')
+    expect(mock_example_file).to include('vi.fn()')
   end
 
   it 'includes the dotenv monkeypatch' do


### PR DESCRIPTION
Se arreglan algunos errores que salieron generando un nuevo proyecto, relacionados a CI:

- Había un `run` con la indentación mala, tiraba error en CI
- El step de repo analyzer estaba usando el `app_name` cuyo valor viene definido en rails, [dónde se le aplica un underscore](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/app_name.rb#L10). Esto provocaba que si uno ponía un nombre con guiones `-`, como suelen ser nuestros proyectos, en el config quedara igual con guión bajo. Se mueve el create de CI para que sea después del de github, cosa de usar el nombre definido en ese step, o la versión dasherizada como default
- También CI se caía en el coverage de front, ya que el comando `./node_modules/.bin/format-coverage coverage/input_vitest.txt coverage/output_vitest.txt /home/circleci/project/app/frontend` no estaba generando un `outpu_vitest.txt`. Esto pasaba porque no se estaba corriendo los tests con reporte de coverage (debería haber sido `vitest run --coverage`), por lo que la transformación terminaba siendo vacía, no se generaba el archivo, y el `cat` siguiente tiraba error. Pensando en fomentar más los tests de sistema vs tener una suite muy exhaustiva de tests unitarios en front, se saca derechamente el reporte de coverage
  - Como parte de esto, se sacó todos los restos que quedaban de jest