### PR TITLE
Redis session

### DIFF
--- a/lib/potassium/assets/.circleci/config.yml.erb
+++ b/lib/potassium/assets/.circleci/config.yml.erb
@@ -4,9 +4,7 @@ ruby-image: &ruby-image cimg/ruby:<%= ruby_version %>
 <%- if selected?(:database, :postgresql) -%>
 postgres-image: &postgres-image postgres:<%= Potassium::POSTGRES_VERSION %>
 <%- end -%>
-<%- if selected?(:background_processor) -%>
-redis-image: &redis-image redis
-<%- end -%>
+redis-image: &redis-image cimg/redis:6.2.12
 env-vars: &env-vars
   BUNDLE_JOBS: 4
   BUNDLE_PATH: vendor/bundle
@@ -23,9 +21,7 @@ executors:
       <%- if selected?(:database, :postgresql) -%>
       - image: *postgres-image
       <%- end -%>
-      <%- if selected?(:background_processor) -%>
       - image: *redis-image
-      <%- end -%>
 
   lint-executor:
     docker:
@@ -94,11 +90,10 @@ jobs:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
 
-      <%- if selected?(:background_processor) -%>
       - run:
           name: Wait for redis service
           command: dockerize -wait tcp://localhost:6379 -timeout 1m
-      <%- end -%>
+
       <%- if selected?(:database, :postgresql) -%>
       - run:
           name: Wait for postgres service

--- a/lib/potassium/assets/config/initializers/session_store.rb
+++ b/lib/potassium/assets/config/initializers/session_store.rb
@@ -1,0 +1,20 @@
+# https://github.com/redis-store/redis-store/issues/358#issuecomment-1537920008
+class RedisClient::Config
+  alias original_initialize initialize
+
+  def initialize(**kwargs)
+    # remove not supported kwargs
+    original_initialize(
+      **kwargs.except(:raw, :serializer, :marshalling, :namespace, :scheme)
+    )
+  end
+end
+
+Rails.application.config.session_store :redis_store, {
+  servers: [{
+    url: ENV['REDIS_URL']
+  }],
+  expire_after: 30.days,
+  key: '_app_session',
+  secure: Rails.env.production?
+}

--- a/lib/potassium/recipes/background_processor.rb
+++ b/lib/potassium/recipes/background_processor.rb
@@ -14,8 +14,6 @@ class Recipes::BackgroundProcessor < Rails::AppBuilder
   def create
     if get(:background_processor)
       add_sidekiq
-      add_docker_compose_redis_config
-      set_redis_dot_env
     end
   end
 
@@ -40,7 +38,6 @@ class Recipes::BackgroundProcessor < Rails::AppBuilder
       append_to_file(".env.development", "DB_POOL=25\n")
       template("../assets/sidekiq.rb.erb", "config/initializers/sidekiq.rb", force: true)
       copy_file("../assets/sidekiq.yml", "config/sidekiq.yml", force: true)
-      copy_file("../assets/redis.yml", "config/redis.yml", force: true)
       recipe.mount_sidekiq_routes
     end
   end
@@ -67,33 +64,6 @@ class Recipes::BackgroundProcessor < Rails::AppBuilder
   end
 
   private
-
-  def add_docker_compose_redis_config
-    compose = DockerHelpers.new('docker-compose.yml')
-
-    service_definition =
-      <<~YAML
-        image: redis
-        ports:
-          - 6379
-        volumes:
-          - redis_data:/data
-      YAML
-
-    compose.add_service('redis', service_definition)
-    compose.add_volume('redis_data')
-  end
-
-  def set_redis_dot_env
-    append_to_file(
-      '.env.development',
-      <<~TEXT
-        REDIS_HOST=127.0.0.1
-        REDIS_PORT=COMMAND_EXPAND(make services-port SERVICE=redis PORT=6379)
-        REDIS_URL=redis://${REDIS_HOST}:${REDIS_PORT}/1
-      TEXT
-    )
-  end
 
   def enabled_mailer?
     mailer_answer = get(:email_service)

--- a/lib/potassium/recipes/redis.rb
+++ b/lib/potassium/recipes/redis.rb
@@ -3,6 +3,7 @@ class Recipes::Redis < Rails::AppBuilder
     add_redis
     add_docker_compose_redis_config
     set_redis_dot_env
+    add_session_store_config
   end
 
   def install
@@ -47,5 +48,10 @@ class Recipes::Redis < Rails::AppBuilder
         REDIS_URL=redis://${REDIS_HOST}:${REDIS_PORT}/1
       TEXT
     )
+  end
+
+  def add_session_store_config
+    copy_file("../assets/config/initializers/session_store.rb",
+              "config/initializers/session_store.rb", force: true)
   end
 end

--- a/lib/potassium/recipes/redis.rb
+++ b/lib/potassium/recipes/redis.rb
@@ -1,0 +1,51 @@
+class Recipes::Redis < Rails::AppBuilder
+  def create
+    add_redis
+    add_docker_compose_redis_config
+    set_redis_dot_env
+  end
+
+  def install
+    create
+  end
+
+  def installed?
+    gem_exists?(/redis-actionpack/)
+  end
+
+  def add_redis
+    run_action(:install_redis) do
+      gather_gem("redis-actionpack")
+      copy_file("../assets/redis.yml", "config/redis.yml", force: true)
+    end
+  end
+
+  private
+
+  def add_docker_compose_redis_config
+    compose = DockerHelpers.new('docker-compose.yml')
+
+    service_definition =
+      <<~YAML
+        image: redis:6.2.12
+        ports:
+          - 6379
+        volumes:
+          - redis_data:/data
+      YAML
+
+    compose.add_service('redis', service_definition)
+    compose.add_volume('redis_data')
+  end
+
+  def set_redis_dot_env
+    append_to_file(
+      '.env.development',
+      <<~TEXT
+        REDIS_HOST=127.0.0.1
+        REDIS_PORT=COMMAND_EXPAND(make services-port SERVICE=redis PORT=6379)
+        REDIS_URL=redis://${REDIS_HOST}:${REDIS_PORT}/1
+      TEXT
+    )
+  end
+end

--- a/lib/potassium/templates/application.rb
+++ b/lib/potassium/templates/application.rb
@@ -45,6 +45,7 @@ run_action(:recipe_loading) do
   create :yarn
   create :editorconfig
   create :mailer
+  create :redis
   create :background_processor
   create :schedule
   create :i18n

--- a/spec/features/redis_spec.rb
+++ b/spec/features/redis_spec.rb
@@ -34,5 +34,10 @@ RSpec.describe "RedisProcessor" do
 
       expect(compose_content[:services]).to include(:redis)
     end
+
+    it 'copies session store config' do
+      content = IO.read("#{project_path}/config/initializers/session_store.rb")
+      expect(content).to include("RedisClient::Config")
+    end
   end
 end

--- a/spec/features/redis_spec.rb
+++ b/spec/features/redis_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+require 'yaml'
+
+RSpec.describe "RedisProcessor" do
+  before :all do
+    drop_dummy_database
+    remove_project_directory
+    create_dummy_project("heroku" => true)
+  end
+
+  context "when installed" do
+    it "adds redis-actionpack gem to Gemfile" do
+      gemfile_content = IO.read("#{project_path}/Gemfile")
+      expect(gemfile_content).to include("redis-actionpack")
+    end
+
+    it "adds ENV vars" do
+      content = IO.read("#{project_path}/.env.development")
+      expect(content).to include('REDIS_HOST=127.0.0.1')
+      expect(content).to include(
+        'REDIS_PORT=COMMAND_EXPAND(make services-port SERVICE=redis PORT=6379)'
+      )
+      expect(content).to include('REDIS_URL=redis://${REDIS_HOST}:${REDIS_PORT}/1')
+    end
+
+    it "adds redis.yml file" do
+      content = IO.read("#{project_path}/config/redis.yml")
+      expect(content).to include("REDIS_URL")
+    end
+
+    it 'adds redis to docker-compose' do
+      compose_file = IO.read("#{project_path}/docker-compose.yml")
+      compose_content = YAML.safe_load(compose_file, symbolize_names: true)
+
+      expect(compose_content[:services]).to include(:redis)
+    end
+  end
+end


### PR DESCRIPTION
En un Ethical Hacking se encontró la siguiente vulnerabilidad:

> Se detecta que la cookie de sesión de usuario no expira cuando el usuario conectado cierra la sesión. Es posible utilizar la misma cookie en un request en otro navegador y volver a iniciar sesión, sin necesidad de entregar credenciales de autenticación.

Devise se lava las manos (https://github.com/heartcombo/devise/issues/5348) y apunta a la documentación de Rails (https://guides.rubyonrails.org/security.html#replay-attacks-for-cookiestore-sessions) que dice que la mejor solución es no usar CookieStore para guardar sesiones.

Este PR reemplaza CookieStore con Redis. Así, Devise puede borrar la sesión en el store e invalidar la cookie sin importar si alguien la ha copiado o no.

Hay otras alternativas pero todas son medias hacky comparadas con simplemente reemplazar CookieStore.