### PR TITLE
feat(vue-admin): comment out the vue mount point

### DIFF
--- a/lib/potassium/recipes/vue_admin.rb
+++ b/lib/potassium/recipes/vue_admin.rb
@@ -136,7 +136,17 @@ class Recipes::VueAdmin < Rails::AppBuilder
             },
           });
           app.component('admin_component', AdminComponent);
-          app.mount('#wrapper');
+
+          // Avoid using '#wrapper' as the mount point, as that includes the entire admin page,
+          // which could be used for Client-Side Template Injection (CSTI) attacks. Limit the
+          // mount point to specific areas where you need Vue components.
+
+          // DO NOT mount Vue in elements that contain user input rendered by
+          // ActiveAdmin.
+          // By default ActiveAdmin doesn't escape {{ }} in user input, so it's
+          // possible to inject arbitrary JavaScript code into the page.
+
+          // app.mount('#wrapper');
         }
 
         return null;


### PR DESCRIPTION
En un Ethical Hacking se encontró que nuestra forma de usar Vue en el admin es vulnerable a ataques de Client-Side Template Injection. Por ejemplo si un usuario escribe `{{ 13 + 13 }}`, en el admin en las vistas de Index y Show se va a ver como `26`. Esto puede ser cualquier tipo de javascript (detalles: https://book.hacktricks.xyz/pentesting-web/client-side-template-injection-csti#vuejs )

Este fix comenta el mount de Vue para que sea una decisión explícita el montar Vue en un elemento.