### PR TITLE
feat(admin): disable comments

### DIFF
--- a/lib/potassium/recipes/admin.rb
+++ b/lib/potassium/recipes/admin.rb
@@ -52,6 +52,7 @@ class Recipes::Admin < Rails::AppBuilder
             meta_tags_options = { viewport: 'width=device-width, initial-scale=1' }
             config.meta_tags = meta_tags_options
             config.meta_tags_for_logged_out_pages = meta_tags_options
+            config.comments = false
         HERE
       end
 


### PR DESCRIPTION
En un Ethical Hacking se encontró que los comentarios de Active Admin no sanitizan el HTML ingresado, lo que permitiría guardar y mostrar cualquier tipo de contenido. El alcance de esta vulnerabilidad es super limitado (solo afectaría a admins) pero de todas maneras, como en general no usamos los comments, mejor partir con ellos desactivados.