### PR TITLE
Change some rspec rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -528,3 +528,7 @@ RSpec/ExpectChange:
   EnforcedStyle: block
 RSpec/BeforeAfterAll:
   Enabled: false
+RSpec/Focus:
+  AutoCorrect: false
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false

--- a/lib/potassium/assets/.rubocop.yml
+++ b/lib/potassium/assets/.rubocop.yml
@@ -588,3 +588,7 @@ RSpec/LetSetup:
 RSpec/ExpectChange:
   Enabled: true
   EnforcedStyle: block
+RSpec/Focus:
+  AutoCorrect: false
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false

--- a/spec/features/mailer_spec.rb
+++ b/spec/features/mailer_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rspec/MultipleMemoizedHelpers
 require "spec_helper"
 
 RSpec.describe "Mailer" do
@@ -102,4 +101,3 @@ RSpec.describe "Mailer" do
     end
   end
 end
-# rubocop:enable Rspec/MultipleMemoizedHelpers

--- a/spec/front_end_vite_spec.rb
+++ b/spec/front_end_vite_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable RSpec/MultipleMemoizedHelpers
 require 'spec_helper'
 
 RSpec.describe 'Front end' do
@@ -78,4 +77,3 @@ RSpec.describe 'Front end' do
     expect(File.exists?(File.join(project_path, 'lib/dotenv_monkeypatch.rb'))).to be(true)
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
Un par de cambios a reglas de rubocop-rspec, tanto para potassium como para los proyectos que genera:
- Se desactiva el autocorrect en la regla `RSpec/Focus`, que no permitía correr solo algunos tests mientras se prueba en local ya que se borraba el focus al guardar.
- Aproveché también de desactivar una regla que hemos hablado en slack un par de veces: `RSpec/MultipleMemoizedHelpers`. Esta no dejaba tener más de 5 lets en un contexto, contando los definidos en contextos padres. Se sacan un par de disables de esta regla en potassium mismo