### PR TITLE
fix(): fix tsconfig vite and vitest config

### DIFF
--- a/lib/potassium/assets/.eslintrc.json
+++ b/lib/potassium/assets/.eslintrc.json
@@ -3,7 +3,6 @@
     "browser": true,
     "es2021": true,
     "node": true,
-    "vi": true,
     "vue/setup-compiler-macros": true
   },
   "parserOptions": {

--- a/lib/potassium/assets/tsconfig.config.json
+++ b/lib/potassium/assets/tsconfig.config.json
@@ -1,8 +1,18 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.node.json",
-  "include": ["vite.config.*", "vitest.config.*", "cypress.config.*", "playwright.config.*"],
+  "extends": [
+    "@tsconfig/node14/tsconfig.json",
+    "@vue/tsconfig/tsconfig.json"
+  ],
+  "include": [
+    "vite.config.*",
+    "vitest.config.*",
+    "cypress.config.*",
+    "playwright.config.*"
+  ],
   "compilerOptions": {
     "composite": true,
-    "types": ["node", "vitest/globals"]
+    "types": [
+      "node"
+    ]
   }
 }

--- a/lib/potassium/assets/tsconfig.json
+++ b/lib/potassium/assets/tsconfig.json
@@ -1,13 +1,19 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.web.json",
-  "include": ["env.d.ts", "app/**/*", "app/**/*.vue"],
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "include": [
+    "env.d.ts",
+    "app/**/*",
+    "app/**/*.vue"
+  ],
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./app/frontend/*"]
-    }
+      "@/*": [
+        "./app/frontend/*"
+      ]
+    },
+    "types": ["vitest/globals", "vite/client"]
   },
-
   "references": [
     {
       "path": "./tsconfig.config.json"

--- a/lib/potassium/recipes/front_end_vite.rb
+++ b/lib/potassium/recipes/front_end_vite.rb
@@ -23,6 +23,7 @@ class Recipes::FrontEndVite < Rails::AppBuilder
       "vue@#{VUE_VERSION}"
     ],
     vue_dev: [
+      "@tsconfig/node14",
       "@vitejs/plugin-vue",
       "@vue/tsconfig",
       "vue-tsc"


### PR DESCRIPTION
Se arreglan un par de cosas relacionadas a ts y vitest:
- Se hacen cambios en la tsconfig relacionados a vue [para soportar TS v5](https://github.com/vuejs/tsconfig#migrating-from-typescript--50)
- Se agrega vite/client [para soportar importación de assets](https://vitejs.dev/guide/features.html#client-types) (como svgs) 
- [Se mueven los globals de vitest al lugar correcto](https://vitest.dev/config/#globals)