### PR TITLE
Feat/api params serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+Features
+  - Add params serializer to API client [#449](https://github.com/platanus/potassium/pull/449)
+
 ## 7.2.0
 Features
   - Use repo_analyzer from docker image [#448](https://github.com/platanus/potassium/pull/448)

--- a/lib/potassium/assets/app/frontend/api/index.ts
+++ b/lib/potassium/assets/app/frontend/api/index.ts
@@ -1,6 +1,7 @@
 import axios, { type AxiosRequestTransformer, type AxiosResponseTransformer } from 'axios';
 import { convertKeys, type objectToConvert } from '../utils/case-converter';
 import { csrfToken } from '../utils/csrf-token';
+import { paramsSerializer } from '../utils/query-params';
 
 const api = axios.create({
   transformRequest: [
@@ -16,6 +17,7 @@ const api = axios.create({
     'Accept': 'application/json',
     'X-CSRF-Token': csrfToken(),
   },
+  paramsSerializer,
 });
 
 export { api };

--- a/lib/potassium/assets/app/frontend/utils/query-params.ts
+++ b/lib/potassium/assets/app/frontend/utils/query-params.ts
@@ -1,0 +1,8 @@
+import { decamelizeKeys } from 'humps';
+import { stringify } from 'qs';
+
+export function paramsSerializer(params: object) {
+  const decamelizedParams = decamelizeKeys(params);
+
+  return stringify(decamelizedParams, { arrayFormat: 'brackets' });
+}

--- a/lib/potassium/recipes/front_end_vite.rb
+++ b/lib/potassium/recipes/front_end_vite.rb
@@ -35,10 +35,12 @@ class Recipes::FrontEndVite < Rails::AppBuilder
     ],
     api: [
       "axios",
-      "humps"
+      "humps",
+      "qs"
     ],
     api_dev: [
-      "@types/humps"
+      "@types/humps",
+      "@types/qs"
     ]
   }
 
@@ -124,6 +126,8 @@ class Recipes::FrontEndVite < Rails::AppBuilder
               'app/frontend/utils/case-converter.ts'
     copy_file '../assets/app/frontend/utils/csrf-token.ts',
               'app/frontend/utils/csrf-token.ts'
+    copy_file '../assets/app/frontend/utils/query-params.ts',
+              'app/frontend/utils/query-params.ts'
   end
 
   def add_vite_dev_ws_content_security_policy

--- a/spec/front_end_vite_spec.rb
+++ b/spec/front_end_vite_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Front end' do
   let(:api_index_file) { read_file('app/frontend/api/index.ts') }
   let(:case_converter_file) { read_file('app/frontend/utils/case-converter.ts') }
   let(:csrf_token_file) { read_file('app/frontend/utils/csrf-token.ts') }
+  let(:query_params_file) { read_file('app/frontend/utils/query-params.ts') }
   let(:mock_example_file) { read_file('app/frontend/api/__mocks__/index.mock.ts') }
 
   it 'creates a project with vite' do
@@ -60,12 +61,14 @@ RSpec.describe 'Front end' do
   it 'includes correct packages for basic api client' do
     expect(node_modules_file).to include('"axios"')
     expect(node_modules_file).to include('"humps"')
+    expect(node_modules_file).to include('"qs"')
   end
 
   it 'includes api client files' do
     expect(api_index_file).to include('axios.create')
     expect(case_converter_file).to include('humps')
     expect(csrf_token_file).to include('meta[name=csrf-token]')
+    expect(query_params_file).to include('humps', 'qs')
   end
 
   it 'includes mock example' do


### PR DESCRIPTION
## Context
Potassium-generated applications use APIs to send and receive data between their backend and their frontend. Since both sides use different case conventions for hash keys, a conversion is required for each data exchange. 

In #412, an API client was added to the frontend that included case conversion for request bodies. But request query params still don't have case conversion, so it's implemented wherever necessary, usually resulting in code repetition.

## What has been done
**Summary:**
A params serializer has been added to the frontend API client that converts the params casing as needed.

To implement this, a query params util was created with one feature: converting an object into a valid URL query string, with keys in snake_case.

**Commits:**
1. Adds the `qs` dependency to the frontend, to handle the conversion of objects into valid query params.
2. Creates a `query-params` util, to take a JavaScript object and return a valid URL query string with snake_case keys.
3. Include params serialization in the frontend's API client, to apply the param serialization in every request made from that client.

### Extra info
The [qs](https://github.com/ljharb/qs) library was used for stringifying params because it was suggested in Axios docs and looks well maintained. If we don't want to add an extra dependency, it could be replaced by a custom solution, but it will probably be less robust. 
