### PR TITLE
perf(testing): ignore irrelevant folders in guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 Features
   - Add params serializer to API client [#449](https://github.com/platanus/potassium/pull/449)
+  - Ignore irrelevant folders in guard [#450](https://github.com/platanus/potassium/pull/450)
 
 ## 7.2.0
 Features

--- a/lib/potassium/recipes/testing.rb
+++ b/lib/potassium/recipes/testing.rb
@@ -62,7 +62,13 @@ class Recipes::Testing < Rails::AppBuilder
     run "bundle binstub guard"
     line = /guard :rspec, cmd: "bundle exec rspec" do\n/
     gsub_file 'Guardfile', line do
-      "guard :rspec, cmd: \"bin/rspec\" do\n"
+      <<~HERE
+        ignore(
+          [%r{^bin/*}, %r{^config/*}, %r{^db/*}, %r{^log/*}, %r{^public/*}, %r{^tmp/*}, %r{^node_modules/*}]
+        )
+
+        guard :rspec, cmd: \"bin/rspec\" do
+      HERE
     end
   end
 

--- a/spec/features/testing_spec.rb
+++ b/spec/features/testing_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "Testing" do
   let(:gemfile_content) { IO.read("#{project_path}/Gemfile") }
   let(:rails_helper_content) { IO.read("#{project_path}/spec/rails_helper.rb") }
   let(:rspec_content) { IO.read("#{project_path}/.rspec") }
+  let(:guard_content) { IO.read("#{project_path}/Guardfile") }
 
   let(:support_directories) do
     %w{
@@ -48,7 +49,8 @@ RSpec.describe "Testing" do
   it { expect(Dir.entries("#{project_path}/spec/support/configurations")).to include(*conf_files) }
 
   it { expect(IO.read("#{project_path}/bin/rspec")).to include('path("rspec-core", "rspec")') }
-  it { expect(IO.read("#{project_path}/Guardfile")).to include(':rspec, cmd: "bin/rspec"') }
+  it { expect(guard_content).to include(':rspec, cmd: "bin/rspec"') }
+  it { expect(guard_content).to include('ignore(') }
   it { expect(IO.read("#{project_path}/bin/guard")).to include('path("guard", "guard")') }
 
   it { expect(IO.read("#{project_path}/README.md")).to include("To run unit test") }


### PR DESCRIPTION
En un par de proyectos más antiguos, guard estaba tomando mucho tiempo (un par de decenas de segundos en vez de un par de segundos en otros proyectos. Este PR agrega un ignore al Guardfile, que le dice a guard [ignore ciertos directorios](https://github.com/guard/guard/wiki/Guardfile-DSL---Configuring-Guard#ignore), en particular node_modules que no viene ignorado por defecto, y otros. En los proyectos que tenían este problema, esta configuración normalizó los tiempos