### PR TITLE
feat(i18n): remove i18n fallback config in prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 Features
   - Add params serializer to API client [#449](https://github.com/platanus/potassium/pull/449)
   - Ignore irrelevant folders in guard [#450](https://github.com/platanus/potassium/pull/450)
+  - Use same locale fallback in all environments [#451](https://github.com/platanus/potassium/pull/451)
 
 ## 7.2.0
 Features

--- a/lib/potassium/recipes/i18n.rb
+++ b/lib/potassium/recipes/i18n.rb
@@ -21,5 +21,6 @@ class Recipes::I18n < Rails::AppBuilder
 
     application("config.i18n.default_locale = '#{get(:lang)}'")
     application("config.i18n.fallbacks = [:es, :en]")
+    gsub_file 'config/environments/production.rb', "config.i18n.fallbacks = true\n", ''
   end
 end

--- a/spec/features/i18n_spec.rb
+++ b/spec/features/i18n_spec.rb
@@ -14,9 +14,11 @@ RSpec.describe "I18n" do
   end
 
   it "configures application.rb" do
-    content = IO.read("#{project_path}/config/application.rb")
+    application_config = IO.read("#{project_path}/config/application.rb")
+    production_config = IO.read("#{project_path}/config/environments/production.rb")
 
-    expect(content).to include("config.i18n.default_locale = 'es-CL'")
-    expect(content).to include("config.i18n.fallbacks = [:es, :en]")
+    expect(application_config).to include("config.i18n.default_locale = 'es-CL'")
+    expect(application_config).to include("config.i18n.fallbacks = [:es, :en]")
+    expect(production_config).not_to include("config.i18n.fallbacks = true")
   end
 end


### PR DESCRIPTION
### Contexto
Potassium agrega i18n y `es-CL` o `en` como idioma por defecto. También agrega un par de fallbacks.

### Este PR

Este PR saca una configuración que se agregaba por defecto en `production.rb`, `config.i18n.fallbacks = true`. Potassium ya configura los callbacks en el `application.rb` con otro valor, entonces estaba pasando que la configuración en producción y local eran diferentes.
En la mayoría de los casos no es mucho problema, ya que en ambos toma el idioma seleccionado, `es-CL`. Pero en caso de no tener una traducción, en local pasaba a los fallbacks `es` y `en`, mientras que en producción tiraba un error de translation missing