### PR TITLE
Feat/sidekiq queues

### DIFF
--- a/lib/potassium/assets/sidekiq.yml
+++ b/lib/potassium/assets/sidekiq.yml
@@ -1,4 +1,6 @@
 production:
   :concurrency: 5
 :queues:
-  - default
+  - ["critical", 6]
+  - ["default", 2]
+  - ["low", 1]

--- a/lib/potassium/recipes/mailer.rb
+++ b/lib/potassium/recipes/mailer.rb
@@ -24,16 +24,12 @@ class Recipes::Mailer < Rails::AppBuilder
     dependencies(email_service)
     config(email_service)
 
-    ensure_sidekiq_install_and_add_mailers_queue
+    ensure_sidekiq_install
   end
 
   def install
     ask
     create
-  end
-
-  def add_mailer_queue
-    insert_into_file "config/sidekiq.yml", "  - mailers", after: "- default\n"
   end
 
   private
@@ -115,16 +111,12 @@ class Recipes::Mailer < Rails::AppBuilder
     application "config.action_mailer.delivery_method = :letter_opener", env: "development"
   end
 
-  def ensure_sidekiq_install_and_add_mailers_queue
+  def ensure_sidekiq_install
     background_processor_recipe = load_recipe(:background_processor)
     background_processor_answer = get(:background_processor)
 
-    if background_processor_recipe.installed?
-      add_mailer_queue
-    else
-      recipe = self
-      after(:install_sidekiq) { recipe.add_mailer_queue }
-      background_processor_recipe.add_sidekiq unless background_processor_answer
+    unless background_processor_recipe.installed? || background_processor_answer
+      background_processor_recipe.add_sidekiq
     end
   end
 end

--- a/spec/features/background_processor_spec.rb
+++ b/spec/features/background_processor_spec.rb
@@ -2,78 +2,76 @@ require "spec_helper"
 require 'yaml'
 
 RSpec.describe "BackgroundProcessor" do
-  context "when working with sidekiq and no mailer" do
-    before :all do
-      drop_dummy_database
-      remove_project_directory
-      create_dummy_project("background_processor" => true, "heroku" => true)
-    end
+  before :all do
+    drop_dummy_database
+    remove_project_directory
+    create_dummy_project("background_processor" => true, "heroku" => true)
+  end
 
-    it "adds sidekiq gem to Gemfile" do
-      gemfile_content = IO.read("#{project_path}/Gemfile")
-      expect(gemfile_content).to include("sidekiq")
-    end
+  it "adds sidekiq gem to Gemfile" do
+    gemfile_content = IO.read("#{project_path}/Gemfile")
+    expect(gemfile_content).to include("sidekiq")
+  end
 
-    it "adds queue_adapter to application.rb" do
-      content = IO.read("#{project_path}/config/application.rb")
-      expect(content).to include("config.active_job.queue_adapter = :sidekiq")
-    end
+  it "adds queue_adapter to application.rb" do
+    content = IO.read("#{project_path}/config/application.rb")
+    expect(content).to include("config.active_job.queue_adapter = :sidekiq")
+  end
 
-    it "adds async queue_adapter to development.rb" do
-      content = IO.read("#{project_path}/config/environments/development.rb")
-      expect(content).to include("config.active_job.queue_adapter = :async")
-    end
+  it "adds async queue_adapter to development.rb" do
+    content = IO.read("#{project_path}/config/environments/development.rb")
+    expect(content).to include("config.active_job.queue_adapter = :async")
+  end
 
-    it "adds test queue_adapter to test.rb" do
-      content = IO.read("#{project_path}/config/environments/test.rb")
-      expect(content).to include("config.active_job.queue_adapter = :test")
-    end
+  it "adds test queue_adapter to test.rb" do
+    content = IO.read("#{project_path}/config/environments/test.rb")
+    expect(content).to include("config.active_job.queue_adapter = :test")
+  end
 
-    it "modifies Procfile" do
-      content = IO.read("#{project_path}/Procfile")
-      expect(content).to include("worker: bundle exec sidekiq")
-    end
+  it "modifies Procfile" do
+    content = IO.read("#{project_path}/Procfile")
+    expect(content).to include("worker: bundle exec sidekiq")
+  end
 
-    it "modifies README" do
-      content = IO.read("#{project_path}/README.md")
-      expect(content).to include("this project uses [Sidekiq]")
-    end
+  it "modifies README" do
+    content = IO.read("#{project_path}/README.md")
+    expect(content).to include("this project uses [Sidekiq]")
+  end
 
-    it "adds ENV vars" do
-      content = IO.read("#{project_path}/.env.development")
-      expect(content).to include("DB_POOL=25")
-      expect(content).to include('REDIS_HOST=127.0.0.1')
-      expect(content).to include('REDIS_PORT=COMMAND_EXPAND(make services-port SERVICE=redis PORT=6379)')
-      expect(content).to include('REDIS_URL=redis://${REDIS_HOST}:${REDIS_PORT}/1')
-    end
+  it "adds ENV vars" do
+    content = IO.read("#{project_path}/.env.development")
+    expect(content).to include("DB_POOL=25")
+    expect(content).to include('REDIS_HOST=127.0.0.1')
+    expect(content).to include(
+      'REDIS_PORT=COMMAND_EXPAND(make services-port SERVICE=redis PORT=6379)'
+    )
+    expect(content).to include('REDIS_URL=redis://${REDIS_HOST}:${REDIS_PORT}/1')
+  end
 
-    it "adds sidekiq.rb file" do
-      content = IO.read("#{project_path}/config/initializers/sidekiq.rb")
-      expect(content).to include("require 'sidekiq'")
-    end
+  it "adds sidekiq.rb file" do
+    content = IO.read("#{project_path}/config/initializers/sidekiq.rb")
+    expect(content).to include("require 'sidekiq'")
+  end
 
-    it "adds sidekiq.yml file with no mailer queue" do
-      yml_path = "#{project_path}/config/sidekiq.yml"
-      content = IO.read(yml_path)
-      expect(File.exist?(yml_path)).to be true
-      expect(content).not_to include("- mailers")
-    end
+  it "adds sidekiq.yml file" do
+    yml_path = "#{project_path}/config/sidekiq.yml"
+    expect(File.exist?(yml_path)).to be true
+  end
 
-    it "adds redis.yml file" do
-      content = IO.read("#{project_path}/config/redis.yml")
-      expect(content).to include("REDIS_URL")
-    end
+  it "adds redis.yml file" do
+    content = IO.read("#{project_path}/config/redis.yml")
+    expect(content).to include("REDIS_URL")
+  end
 
-    it "mounts sidekiq app" do
-      content = IO.read("#{project_path}/config/routes.rb")
-      expect(content).to include("mount Sidekiq::Web => '/queue'")
-    end
+  it "mounts sidekiq app" do
+    content = IO.read("#{project_path}/config/routes.rb")
+    expect(content).to include("mount Sidekiq::Web => '/queue'")
+  end
 
-    it 'adds redis to docker-compose' do
-      compose_file = IO.read("#{project_path}/docker-compose.yml")
-      compose_content = YAML.safe_load(compose_file, symbolize_names: true)
+  it 'adds redis to docker-compose' do
+    compose_file = IO.read("#{project_path}/docker-compose.yml")
+    compose_content = YAML.safe_load(compose_file, symbolize_names: true)
 
-      expect(compose_content[:services]).to include(:redis)
-    end
+    expect(compose_content[:services]).to include(:redis)
   end
 end

--- a/spec/features/mailer_spec.rb
+++ b/spec/features/mailer_spec.rb
@@ -66,18 +66,6 @@ RSpec.describe "Mailer" do
       it { expect(mailer_config).to include("delivery_method = :aws_sdk") }
       it { expect(dev_config).to include("delivery_method = :letter_opener") }
     end
-
-    context "when selecting a mailer and sidekiq" do
-      before :all do
-        drop_dummy_database
-        remove_project_directory
-        create_dummy_project(
-          "background_processor" => true, "email_service" => 'sendgrid'
-        )
-      end
-
-      it { expect(sidekiq_config).to include("- mailers") }
-    end
   end
 
   context "when there is no mailer" do

--- a/spec/features/schedule_spec.rb
+++ b/spec/features/schedule_spec.rb
@@ -20,10 +20,6 @@ RSpec.describe "schedule" do
     expect(sidekiq_config).to include(":schedule:")
   end
 
-  it "doesn't remove mailers queue" do
-    expect(sidekiq_config).to include("- mailers")
-  end
-
   it "adds scheduler ui to the sidekiq initializer" do
     content = IO.read("#{project_path}/config/initializers/sidekiq.rb")
     expect(content).to include("require 'sidekiq-scheduler/web'")

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,5 +1,4 @@
 RSpec.shared_examples "name" do
-  it { expect(sidekiq_config).to include("- mailers") }
   it { expect(env).to include("EMAIL_RECIPIENTS") }
   it { expect(dev_config).to include(asset_host_dev) }
 end


### PR DESCRIPTION
## Context
Potassium allows setting sidekiq for background job processing. Currently, the sidekiq.yml queue configuration has a single default queue, and a "mailers" queue is added when the mailer recipe is enabled.

## What has been done
As per the [sidekiq docs](https://github.com/sidekiq/sidekiq/wiki/Advanced-Options), we added the 'critical' and 'low' queues. Based on [this article](https://philsturgeon.com/tips-on-sidekiq-queues/) (following the "reasonable approach" described there), we added weights to the queues to give a chance of running to jobs enqueued in the "low" queue.

We removed the `add_mailer_queue` method from the mailer recipe and renamed the `ensure_sidekiq_install_and_add_mailers_queue` method to only `ensure_sidekiq_install`.

We removed all tests referencing the presence or absence of a mailers queue in the `sidekiq.yml` file

### Extra info

We didn't need to add an explicit configuration for the [`deliver_later_queue_name`](https://edgeguides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration)  because since Rails 6.1 [the default queue for deliver_later method is the default queue for ActiveJob](https://github.com/rails/rails/commit/4d2eeafa70530d031da4ae620f94591fe87bf90a)
