### PR TITLE
F/pundit page policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Features
   - Add params serializer to API client [#449](https://github.com/platanus/potassium/pull/449)
   - Ignore irrelevant folders in guard [#450](https://github.com/platanus/potassium/pull/450)
   - Use same locale fallback in all environments [#451](https://github.com/platanus/potassium/pull/451)
+  - Add ActiveAdmin's page permission and test files for generated policies [#453](https://github.com/platanus/potassium/pull/453)
 
 ## 7.2.0
 Features

--- a/lib/potassium/assets/active_admin/policies/page_policy.rb
+++ b/lib/potassium/assets/active_admin/policies/page_policy.rb
@@ -1,2 +1,5 @@
 class BackOffice::ActiveAdmin::PagePolicy < BackOffice::DefaultPolicy
+  def show?
+    record.name == 'Dashboard'
+  end
 end

--- a/lib/potassium/assets/testing/admin_user_factory.rb
+++ b/lib/potassium/assets/testing/admin_user_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :admin_user do
+    email { Faker::Internet.unique.email }
+    password { 'password' }
+  end
+end

--- a/lib/potassium/assets/testing/pundit/admin_user_policy_spec.rb
+++ b/lib/potassium/assets/testing/pundit/admin_user_policy_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe BackOffice::AdminUserPolicy do
+  include_context 'with pundit setup'
+
+  let(:record) { create(:admin_user) }
+
+  it_behaves_like 'pundit back office - default permissions'
+end

--- a/lib/potassium/assets/testing/pundit/comment_policy_spec.rb
+++ b/lib/potassium/assets/testing/pundit/comment_policy_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe BackOffice::ActiveAdmin::CommentPolicy do
+  include_context 'with pundit setup'
+
+  let(:record) { instance_double('ActiveAdmin::Comment') }
+
+  it_behaves_like 'pundit back office - default permissions'
+end

--- a/lib/potassium/assets/testing/pundit/default_policy_spec.rb
+++ b/lib/potassium/assets/testing/pundit/default_policy_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe BackOffice::DefaultPolicy do
+  include_context 'with pundit setup'
+
+  let(:record) { double }
+
+  it_behaves_like 'pundit back office - default permissions'
+end

--- a/lib/potassium/assets/testing/pundit/page_policy_spec.rb
+++ b/lib/potassium/assets/testing/pundit/page_policy_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe BackOffice::ActiveAdmin::PagePolicy do
+  include_context 'with pundit setup'
+
+  let(:name) { 'Dashboard' }
+  let(:record) { instance_double('ActiveAdmin::Page', name: name) }
+
+  permissions :show? do
+    it_behaves_like 'pundit back office - grant access to admin'
+
+    context "with name different than 'Dashboard'" do
+      let(:name) { 'Not Dashboard' }
+
+      it_behaves_like 'pundit back office - forbid access to admin'
+    end
+  end
+end

--- a/lib/potassium/assets/testing/pundit/shared_examples.rb
+++ b/lib/potassium/assets/testing/pundit/shared_examples.rb
@@ -1,0 +1,69 @@
+RSpec.shared_context 'with pundit setup' do
+  subject(:policy) { described_class }
+
+  let(:admin_user) { create(:admin_user) }
+end
+
+RSpec.shared_examples 'pundit back office - grant access to admin' do
+  it { expect(policy).to permit(admin_user, record) }
+end
+
+RSpec.shared_examples 'pundit back office - forbid access to admin' do
+  it { expect(policy).not_to permit(admin_user, record) }
+end
+
+RSpec.shared_examples 'pundit back office - default permissions' do
+  it_behaves_like 'pundit back office - default show action'
+  it_behaves_like 'pundit back office - default index action'
+  it_behaves_like 'pundit back office - default update action'
+  it_behaves_like 'pundit back office - default edit action'
+  it_behaves_like 'pundit back office - default new action'
+  it_behaves_like 'pundit back office - default create action'
+  it_behaves_like 'pundit back office - default destroy action'
+end
+
+RSpec.shared_examples 'pundit back office - default permission' do
+  it_behaves_like 'pundit back office - grant access to admin'
+end
+
+RSpec.shared_examples 'pundit back office - default show action' do
+  permissions :show? do
+    it_behaves_like 'pundit back office - default permission'
+  end
+end
+
+RSpec.shared_examples 'pundit back office - default index action' do
+  permissions :index? do
+    it_behaves_like 'pundit back office - default permission'
+  end
+end
+
+RSpec.shared_examples 'pundit back office - default create action' do
+  permissions :create? do
+    it_behaves_like 'pundit back office - default permission'
+  end
+end
+
+RSpec.shared_examples 'pundit back office - default update action' do
+  permissions :update? do
+    it_behaves_like 'pundit back office - default permission'
+  end
+end
+
+RSpec.shared_examples 'pundit back office - default new action' do
+  permissions :new? do
+    it_behaves_like 'pundit back office - default permission'
+  end
+end
+
+RSpec.shared_examples 'pundit back office - default edit action' do
+  permissions :edit? do
+    it_behaves_like 'pundit back office - default permission'
+  end
+end
+
+RSpec.shared_examples 'pundit back office - default destroy action' do
+  permissions :destroy? do
+    it_behaves_like 'pundit back office - default permission'
+  end
+end

--- a/lib/potassium/templates/application.rb
+++ b/lib/potassium/templates/application.rb
@@ -55,8 +55,8 @@ run_action(:recipe_loading) do
   create :devise
   create :seeds
   create :error_reporting
-  create :pundit
   create :testing
+  create :pundit
   create :coverage
   create :secrets
   create :api

--- a/spec/features/pundit_spec.rb
+++ b/spec/features/pundit_spec.rb
@@ -21,10 +21,67 @@ RSpec.describe "Pundit" do
     expect(content).to include("config.pundit_policy_namespace = :back_office")
   end
 
-  it "creates default policy" do
-    content = IO.read("#{project_path}/app/policies/back_office/default_policy.rb")
+  it 'creates admin user factory' do
+    content = IO.read("#{project_path}/spec/factories/admin_users.rb")
 
-    expect(content).to include("class BackOffice::DefaultPolicy")
+    expect(content).to include("email { Faker::Internet.unique.email }")
+    expect(content).to include("password")
+  end
+
+  describe 'admin_user policy' do
+    it "creates file" do
+      content = IO.read("#{project_path}/app/policies/back_office/admin_user_policy.rb")
+
+      expect(content).to include('class BackOffice::AdminUserPolicy')
+    end
+
+    it 'creates spec' do
+      content = IO.read("#{project_path}/spec/policies/back_office/admin_user_policy_spec.rb")
+      expect(content).to include('RSpec.describe BackOffice::AdminUserPolicy')
+    end
+  end
+
+  describe 'default policy' do
+    it 'creates file' do
+      content = IO.read("#{project_path}/app/policies/back_office/default_policy.rb")
+
+      expect(content).to include('class BackOffice::DefaultPolicy')
+    end
+
+    it 'creates spec' do
+      content = IO.read("#{project_path}/spec/policies/back_office/default_policy_spec.rb")
+      expect(content).to include('RSpec.describe BackOffice::DefaultPolicy')
+    end
+  end
+
+  describe 'comment policy' do
+    it 'creates file' do
+      content = IO.read("#{project_path}/app/policies/back_office/active_admin/comment_policy.rb")
+
+      expect(content).to include('class BackOffice::ActiveAdmin::CommentPolicy')
+    end
+
+    it 'creates spec' do
+      content = IO.read(
+        "#{project_path}/spec/policies/back_office/active_admin/comment_policy_spec.rb"
+      )
+      expect(content).to include('RSpec.describe BackOffice::ActiveAdmin::CommentPolicy')
+    end
+  end
+
+  describe 'page policy' do
+    it 'creates file' do
+      content = IO.read("#{project_path}/app/policies/back_office/active_admin/page_policy.rb")
+
+      expect(content).to include('class BackOffice::ActiveAdmin::PagePolicy')
+    end
+
+    it 'creates spec' do
+      content = IO.read(
+        "#{project_path}/spec/policies/back_office/active_admin/page_policy_spec.rb"
+      )
+      expect(content).to include('RSpec.describe BackOffice::ActiveAdmin::PagePolicy')
+    end
   end
 
   it "modifies the README file" do


### PR DESCRIPTION
## Context
Potassium-generated applications with Pundit use that gem to allow access to certain resources. Sometimes we add roles to filter which pages can a user see on active admin, and if they don't have permission to see anything (not even the dashboard) the app enters on a redirect loop, leading into an exception.

Also, every Potassium-generated policy files come un-tested.

## What has been done
**Summary:**
PagePolicy has been edited, now when de page is the Dashboard, is always shown to the user. Also, policy tests are now generated with Potassium.

**Commits:**
1. Add Pundit shared examples, which will be useful for every policy spec created in this PR
2. Add the "Always show dashboard" logic to the `PagePolicy`
3. Add missing tests to the policies added in the pundit recipe
4. Modify the pundit recipe and test that every file is copied correctly

### Extra info
EDIT: what I describe below is now fixed, I added a `force: true` to the factory file copy, and now it works perfectly.




All the new generated tests fails on a new app, but this is because de AdminUser factory is created with empty attributes. If the `email` and `password` are added, every test pass.

```ruby
FactoryBot.define do
  factory :admin_user do
    email { Faker::Internet.unique.email }
    password { 'password' }
  end
end
```

My doubt is: is it okay to leave it like that, with failing tests? I tried to modify the AdminUser factory file, but when the pundit recipe is ran, that file is not created yet. Also I tried to copy the AdminUser factory file (like the policies files are copied), but that generates a situation where user input is needed. This is because when the AdminUser factory file is trying to be created, it raises a warning that already exists, and user input is needed in order to decide to skip, abort, overwrite, etc.